### PR TITLE
Chore: Remove duplicate addcmd

### DIFF
--- a/cmd/version.go
+++ b/cmd/version.go
@@ -17,5 +17,4 @@ var versionCmd = &cobra.Command{
 }
 
 func init() {
-	rootCmd.AddCommand(versionCmd)
 }


### PR DESCRIPTION
- Remove duplicate add command ( Resolves issue where version showed twice in list of commands)