### PR TITLE
refactor: hot-path performance, dedup, dead-code removal, and Go modernization

### DIFF
--- a/cmd/completion.go
+++ b/cmd/completion.go
@@ -140,16 +140,11 @@ func registerFilterFlagCompletions(cmd *cobra.Command) {
 	_ = cmd.RegisterFlagCompletionFunc(flagWhere, completeWhereField)
 }
 
-// registerLevelCompletion wires --level value completion on cmd.
-func registerLevelCompletion(cmd *cobra.Command) {
-	_ = cmd.RegisterFlagCompletionFunc(flagLevel, staticFlagCompletion(levelCompletions...))
-}
-
 // addLevelFlag registers the shared --level flag plus its value completion. One
 // definition so `logs` and `parse` agree on the help text and the level list
 // stays in sync with levelCompletions.
 func addLevelFlag(cmd *cobra.Command) {
 	cmd.Flags().StringP(flagLevel, "l", "DEBUG",
 		"Filter logs by level ("+strings.Join(levelCompletions, ", ")+")")
-	registerLevelCompletion(cmd)
+	_ = cmd.RegisterFlagCompletionFunc(flagLevel, staticFlagCompletion(levelCompletions...))
 }

--- a/cmd/completion.go
+++ b/cmd/completion.go
@@ -147,3 +147,12 @@ func registerFilterFlagCompletions(cmd *cobra.Command) {
 func registerLevelCompletion(cmd *cobra.Command) {
 	_ = cmd.RegisterFlagCompletionFunc(flagLevel, staticFlagCompletion(levelCompletions...))
 }
+
+// addLevelFlag registers the shared --level flag plus its value completion. One
+// definition so `logs` and `parse` agree on the help text and the level list
+// stays in sync with levelCompletions.
+func addLevelFlag(cmd *cobra.Command) {
+	cmd.Flags().StringP(flagLevel, "l", "DEBUG",
+		"Filter logs by level ("+strings.Join(levelCompletions, ", ")+")")
+	registerLevelCompletion(cmd)
+}

--- a/cmd/completion.go
+++ b/cmd/completion.go
@@ -4,6 +4,7 @@ import (
 	"os"
 	"strings"
 
+	"github.com/dantech2000/logx/internal/logging"
 	"github.com/spf13/cobra"
 )
 
@@ -53,7 +54,7 @@ func init() {
 // Static value enums offered for flag completion, kept in one place so the help
 // text, parser, and completion agree on what is valid.
 var (
-	levelCompletions  = []string{"TRACE", "DEBUG", "INFO", "WARN", "ERROR", "FATAL"}
+	levelCompletions  = logging.LevelNames()
 	themeCompletions  = []string{"dark", "light"}
 	outputCompletions = []string{"text", "json"}
 	colorCompletions  = []string{"auto", "always", "never"}
@@ -114,16 +115,12 @@ func completeFieldList(_ *cobra.Command, _ []string, toComplete string) ([]strin
 // started typing an operator there is a value we cannot predict, so we stop
 // offering hints (and leave file completion off).
 func completeWhereField(_ *cobra.Command, _ []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-	if strings.ContainsAny(toComplete, operatorChars) {
+	if strings.ContainsAny(toComplete, logging.PredicateOperatorChars) {
 		return nil, cobra.ShellCompDirectiveNoFileComp
 	}
 	// NoSpace so the user can append the operator (e.g. status>=500) without a gap.
 	return filterPrefix(knownFieldNames, toComplete), cobra.ShellCompDirectiveNoSpace | cobra.ShellCompDirectiveNoFileComp
 }
-
-// operatorChars mirrors the predicate operator characters; once any appears in a
-// --where token the user is past the field name.
-const operatorChars = "<>=!~"
 
 // splitLastComma splits s at its final comma into (everything up to and including
 // the comma, the trailing element). With no comma it returns ("", s).

--- a/cmd/config.go
+++ b/cmd/config.go
@@ -85,9 +85,23 @@ func stringDefault(flagValue, configValue string, changed bool) string {
 
 // effectiveLevel resolves the level string with flag > config > built-in default.
 func effectiveLevel(cmd *cobra.Command) (string, error) {
-	level, err := cmd.Flags().GetString(flagLevel)
+	level, err := getStringFlag(cmd, flagLevel)
 	if err != nil {
-		return "", fmt.Errorf("error getting level flag: %w", err)
+		return "", err
 	}
 	return stringDefault(level, loadedConfig.Level, cmd.Flags().Changed(flagLevel)), nil
+}
+
+// effectiveLogLevel resolves and parses the --level value in one step, so the
+// commands that share the flag also share the resolution and error wording.
+func effectiveLogLevel(cmd *cobra.Command) (logging.LogLevel, error) {
+	levelStr, err := effectiveLevel(cmd)
+	if err != nil {
+		return logging.DEBUG, err
+	}
+	level, err := logging.ParseLogLevel(levelStr)
+	if err != nil {
+		return logging.DEBUG, fmt.Errorf("invalid level %q: %w", levelStr, err)
+	}
+	return level, nil
 }

--- a/cmd/config.go
+++ b/cmd/config.go
@@ -1,6 +1,7 @@
 package cmd
 
 import (
+	"cmp"
 	"errors"
 	"fmt"
 	"io/fs"
@@ -77,10 +78,10 @@ func (c fileConfig) applyFieldAliases() {
 // stringDefault returns the config value when the flag was not explicitly set
 // and the config provides one, implementing flag > config > built-in precedence.
 func stringDefault(flagValue, configValue string, changed bool) string {
-	if !changed && configValue != "" {
-		return configValue
+	if changed {
+		return flagValue
 	}
-	return flagValue
+	return cmp.Or(configValue, flagValue)
 }
 
 // effectiveLevel resolves the level string with flag > config > built-in default.

--- a/cmd/config_test.go
+++ b/cmd/config_test.go
@@ -5,6 +5,7 @@ import (
 	"path/filepath"
 	"testing"
 
+	"github.com/dantech2000/logx/internal/logging"
 	"github.com/spf13/cobra"
 )
 
@@ -16,6 +17,59 @@ func writeConfig(t *testing.T, body string) string {
 	}
 	t.Setenv("LOGX_CONFIG", path)
 	return path
+}
+
+func TestConfigPathPrecedence(t *testing.T) {
+	// $LOGX_CONFIG wins outright.
+	t.Setenv("LOGX_CONFIG", "/explicit/config.yaml")
+	t.Setenv("XDG_CONFIG_HOME", "/xdg")
+	if got := configPath(); got != "/explicit/config.yaml" {
+		t.Errorf("configPath() = %q, want $LOGX_CONFIG to win", got)
+	}
+
+	// Without it, $XDG_CONFIG_HOME/logx/config.yaml.
+	t.Setenv("LOGX_CONFIG", "")
+	if got, want := configPath(), filepath.Join("/xdg", "logx", "config.yaml"); got != want {
+		t.Errorf("configPath() = %q, want %q (from $XDG_CONFIG_HOME)", got, want)
+	}
+
+	// Without either, ~/.config/logx/config.yaml.
+	t.Setenv("XDG_CONFIG_HOME", "")
+	home, err := os.UserHomeDir()
+	if err != nil {
+		t.Skipf("no home directory available: %v", err)
+	}
+	if got, want := configPath(), filepath.Join(home, ".config", "logx", "config.yaml"); got != want {
+		t.Errorf("configPath() = %q, want %q (home fallback)", got, want)
+	}
+}
+
+func TestApplyFieldAliasesRegistersConfigFields(t *testing.T) {
+	// Alias registration is deliberately global and additive (a startup-only
+	// operation with no unregister), so this test uses keys namespaced with a
+	// zz_cfg_ prefix that no other test input contains.
+	var cfg fileConfig
+	cfg.Fields.Level = []string{"zz_cfg_level"}
+	cfg.Fields.Message = []string{"zz_cfg_msg"}
+	cfg.applyFieldAliases()
+
+	entry := logging.ParseLogEntry(`{"zz_cfg_level":"error","zz_cfg_msg":"db down"}`)
+	if entry.Level != logging.ERROR || !entry.LevelDetected {
+		t.Errorf("config level alias not applied: level=%v detected=%v", entry.Level, entry.LevelDetected)
+	}
+	if entry.Message != "db down" {
+		t.Errorf("config message alias not applied: %q", entry.Message)
+	}
+}
+
+func TestApplyFieldAliasesEmptyConfigIsNoop(t *testing.T) {
+	var cfg fileConfig
+	cfg.applyFieldAliases() // no fields configured: must not disturb built-ins
+
+	entry := logging.ParseLogEntry(`{"level":"warn","msg":"disk almost full"}`)
+	if entry.Level != logging.WARN || entry.Message != "disk almost full" {
+		t.Errorf("built-in parsing disturbed: level=%v message=%q", entry.Level, entry.Message)
+	}
 }
 
 func TestLoadConfigValid(t *testing.T) {

--- a/cmd/containers.go
+++ b/cmd/containers.go
@@ -51,14 +51,14 @@ func getContainerOptions(cmd *cobra.Command, args []string) (*containerOptions, 
 }
 
 func runContainers(cmd *cobra.Command, args []string) error {
-	clientset, namespace, err := kubernetesClientFromFlags(cmd)
-	if err != nil {
-		return fmt.Errorf("creating kubernetes client: %w", err)
-	}
-
 	opts, err := getContainerOptions(cmd, args)
 	if err != nil {
 		return err
+	}
+
+	clientset, namespace, err := kubernetesClientFromFlags(cmd)
+	if err != nil {
+		return fmt.Errorf("creating kubernetes client: %w", err)
 	}
 
 	containers, err := kubernetes.ListContainers(cmd.Context(), clientset, namespace, opts.podName)

--- a/cmd/logs.go
+++ b/cmd/logs.go
@@ -55,12 +55,11 @@ func addLogFlags(cmd *cobra.Command) {
 	cmd.Flags().BoolP(flagAllContainers, "a", false, "Stream logs from all containers in the pod, prefixed by container name")
 	cmd.Flags().Int(flagMaxConcurrency, 10, "Max container log streams read at once with --all-containers/--selector")
 	cmd.Flags().BoolP(flagFollow, "f", false, "Follow the log output in real-time")
-	cmd.Flags().StringP(flagLevel, "l", "DEBUG", "Filter logs by level (DEBUG, INFO, WARN, ERROR)")
 	cmd.Flags().BoolP(flagPrevious, "p", false, "Get previous terminated container logs")
 	cmd.Flags().Bool(flagTimeline, false, "Show pod logs and Kubernetes events together sorted by time")
+	addLevelFlag(cmd)
 	addFilterFlags(cmd)
 	addLogQueryFlags(cmd)
-	registerLevelCompletion(cmd)
 }
 
 // completePodNames provides dynamic completion for pod names
@@ -178,6 +177,11 @@ func runLogs(cmd *cobra.Command, args []string) error {
 	if err != nil {
 		return err
 	}
+	// Validate before any expensive work (kubeconfig load, client build) so an
+	// invalid flag combination reports the usage error, not a kubeconfig error.
+	if err := validateLogOptions(options); err != nil {
+		return err
+	}
 	filterLevel, err := logging.ParseLogLevel(options.level)
 	if err != nil {
 		return fmt.Errorf("invalid level %q: %w", options.level, err)
@@ -208,10 +212,6 @@ func runLogs(cmd *cobra.Command, args []string) error {
 	logFetcher.AllNamespaces = options.allNamespaces
 	logFetcher.MaxConcurrency = options.maxConcurrency
 	if err := applyLogQuery(cmd, logFetcher); err != nil {
-		return err
-	}
-
-	if err := validateLogOptions(options); err != nil {
 		return err
 	}
 

--- a/cmd/logs.go
+++ b/cmd/logs.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 
 	"github.com/dantech2000/logx/internal/kubernetes"
-	"github.com/dantech2000/logx/internal/logging"
 	"github.com/spf13/cobra"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -20,7 +19,6 @@ type logOptions struct {
 	stats          bool
 	maxConcurrency int
 	follow         bool
-	level          string
 	podName        string
 	previous       bool
 	timeline       bool
@@ -41,11 +39,6 @@ label selector.`,
 func init() {
 	rootCmd.AddCommand(logsCmd)
 	addLogFlags(logsCmd)
-
-	// Add completion for pod names
-	logsCmd.ValidArgsFunction = completePodNames
-	// Add completion for container names
-	_ = logsCmd.RegisterFlagCompletionFunc(flagContainer, completeContainerNames)
 }
 
 func addLogFlags(cmd *cobra.Command) {
@@ -60,6 +53,11 @@ func addLogFlags(cmd *cobra.Command) {
 	addLevelFlag(cmd)
 	addFilterFlags(cmd)
 	addLogQueryFlags(cmd)
+
+	// Pod-name and container-name completion apply to every command that takes
+	// these flags (both `logx logs` and the root `logx [pod]` shorthand).
+	cmd.ValidArgsFunction = completePodNames
+	_ = cmd.RegisterFlagCompletionFunc(flagContainer, completeContainerNames)
 }
 
 // completePodNames provides dynamic completion for pod names
@@ -137,11 +135,6 @@ func getLogOptions(cmd *cobra.Command, args []string) (*logOptions, error) {
 		return nil, err
 	}
 
-	level, err := effectiveLevel(cmd)
-	if err != nil {
-		return nil, err
-	}
-
 	previous, err := getBoolFlag(cmd, flagPrevious)
 	if err != nil {
 		return nil, err
@@ -165,7 +158,6 @@ func getLogOptions(cmd *cobra.Command, args []string) (*logOptions, error) {
 		stats:          stats,
 		maxConcurrency: maxConcurrency,
 		follow:         follow,
-		level:          level,
 		podName:        podName,
 		previous:       previous,
 		timeline:       timeline,
@@ -182,9 +174,9 @@ func runLogs(cmd *cobra.Command, args []string) error {
 	if err := validateLogOptions(options); err != nil {
 		return err
 	}
-	filterLevel, err := logging.ParseLogLevel(options.level)
+	filterLevel, err := effectiveLogLevel(cmd)
 	if err != nil {
-		return fmt.Errorf("invalid level %q: %w", options.level, err)
+		return err
 	}
 
 	pipelineOptions, err := buildPipelineOptions(cmd, filterLevel)

--- a/cmd/logs_test.go
+++ b/cmd/logs_test.go
@@ -12,49 +12,48 @@ func TestGetLogOptionsParsesLevelFlags(t *testing.T) {
 		name      string
 		args      []string
 		wantPod   string
-		wantLevel string
+		wantLevel logging.LogLevel
 	}{
 		{
 			name:      "root command short level flag",
 			args:      []string{"test-pod", "-l", "WARN"},
 			wantPod:   "test-pod",
-			wantLevel: "WARN",
+			wantLevel: logging.WARN,
 		},
 		{
 			name:      "logs subcommand long level flag",
 			args:      []string{"logs", "test-pod", "--level", "ERROR"},
 			wantPod:   "test-pod",
-			wantLevel: "ERROR",
+			wantLevel: logging.ERROR,
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			var gotOptions *logOptions
+			var gotLevel logging.LogLevel
+			capture := func(cmd *cobra.Command, args []string) error {
+				options, err := getLogOptions(cmd, args)
+				if err != nil {
+					return err
+				}
+				level, err := effectiveLogLevel(cmd)
+				if err != nil {
+					return err
+				}
+				gotOptions, gotLevel = options, level
+				return nil
+			}
 			root := &cobra.Command{
 				Use:  "logx [pod-name]",
 				Args: cobra.MaximumNArgs(1),
-				RunE: func(cmd *cobra.Command, args []string) error {
-					options, err := getLogOptions(cmd, args)
-					if err != nil {
-						return err
-					}
-					gotOptions = options
-					return nil
-				},
+				RunE: capture,
 			}
 			addLogFlags(root)
 			logs := &cobra.Command{
 				Use:  "logs [pod-name]",
 				Args: cobra.ExactArgs(1),
-				RunE: func(cmd *cobra.Command, args []string) error {
-					options, err := getLogOptions(cmd, args)
-					if err != nil {
-						return err
-					}
-					gotOptions = options
-					return nil
-				},
+				RunE: capture,
 			}
 			addLogFlags(logs)
 			root.AddCommand(logs)
@@ -69,11 +68,8 @@ func TestGetLogOptionsParsesLevelFlags(t *testing.T) {
 			if gotOptions.podName != tt.wantPod {
 				t.Fatalf("podName = %q, want %q", gotOptions.podName, tt.wantPod)
 			}
-			if gotOptions.level != tt.wantLevel {
-				t.Fatalf("level = %q, want %q", gotOptions.level, tt.wantLevel)
-			}
-			if _, err := logging.ParseLogLevel(gotOptions.level); err != nil {
-				t.Fatalf("ParseLogLevel(%q) error = %v", gotOptions.level, err)
+			if gotLevel != tt.wantLevel {
+				t.Fatalf("level = %v, want %v", gotLevel, tt.wantLevel)
 			}
 		})
 	}
@@ -96,7 +92,7 @@ func TestGetLogOptionsParsesTimelineFlag(t *testing.T) {
 	}
 }
 
-func TestGetLogOptionsRejectsInvalidLevel(t *testing.T) {
+func TestEffectiveLogLevelRejectsInvalidLevel(t *testing.T) {
 	cmd := &cobra.Command{Use: "logs [pod-name]"}
 	addLogFlags(cmd)
 	cmd.SetArgs([]string{"test-pod", "--level", "NOPE"})
@@ -104,12 +100,8 @@ func TestGetLogOptionsRejectsInvalidLevel(t *testing.T) {
 		t.Fatalf("execute command: %v", err)
 	}
 
-	options, err := getLogOptions(cmd, []string{"test-pod"})
-	if err != nil {
-		t.Fatalf("getLogOptions() error = %v", err)
-	}
-	if _, err := logging.ParseLogLevel(options.level); err == nil {
-		t.Fatal("ParseLogLevel() error = nil, want error")
+	if _, err := effectiveLogLevel(cmd); err == nil {
+		t.Fatal("effectiveLogLevel() error = nil, want error")
 	}
 }
 

--- a/cmd/logs_test.go
+++ b/cmd/logs_test.go
@@ -1,6 +1,7 @@
 package cmd
 
 import (
+	"strings"
 	"testing"
 
 	"github.com/dantech2000/logx/internal/logging"
@@ -147,5 +148,23 @@ func TestValidateLogOptionsAllNamespaces(t *testing.T) {
 	}
 	if err := validateLogOptions(&logOptions{allNamespaces: true, selector: "app=api", maxConcurrency: 10}); err != nil {
 		t.Fatalf("--all-namespaces with --selector should be valid, got %v", err)
+	}
+}
+
+// TestLevelFlagHelpListsAllLevels pins that the shared --level help text names
+// every level the parser accepts, guarding against the drift this flag once had
+// (the logs help listed only four of the six levels).
+func TestLevelFlagHelpListsAllLevels(t *testing.T) {
+	cmd := &cobra.Command{Use: "x"}
+	addLevelFlag(cmd)
+
+	flag := cmd.Flags().Lookup(flagLevel)
+	if flag == nil {
+		t.Fatal("--level flag not registered")
+	}
+	for _, name := range logging.LevelNames() {
+		if !strings.Contains(flag.Usage, name) {
+			t.Errorf("--level help %q missing level %s", flag.Usage, name)
+		}
 	}
 }

--- a/cmd/parse.go
+++ b/cmd/parse.go
@@ -30,9 +30,8 @@ Examples:
 
 func init() {
 	rootCmd.AddCommand(parseCmd)
-	parseCmd.Flags().StringP(flagLevel, "l", "DEBUG", "Filter logs by level (TRACE, DEBUG, INFO, WARN, ERROR, FATAL)")
+	addLevelFlag(parseCmd)
 	addFilterFlags(parseCmd)
-	registerLevelCompletion(parseCmd)
 }
 
 func runParse(cmd *cobra.Command, args []string) error {

--- a/cmd/parse.go
+++ b/cmd/parse.go
@@ -35,13 +35,9 @@ func init() {
 }
 
 func runParse(cmd *cobra.Command, args []string) error {
-	levelStr, err := effectiveLevel(cmd)
+	level, err := effectiveLogLevel(cmd)
 	if err != nil {
 		return err
-	}
-	level, err := logging.ParseLogLevel(levelStr)
-	if err != nil {
-		return fmt.Errorf("invalid level %q: %w", levelStr, err)
 	}
 
 	opts, err := buildPipelineOptions(cmd, level)

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -72,6 +72,4 @@ func init() {
 	addKubeFlags(rootCmd)
 	addLogFlags(rootCmd)
 	addOutputFlags(rootCmd)
-	rootCmd.ValidArgsFunction = completePodNames
-	_ = rootCmd.RegisterFlagCompletionFunc(flagContainer, completeContainerNames)
 }

--- a/cmd/run_test.go
+++ b/cmd/run_test.go
@@ -189,3 +189,22 @@ func TestRunLogsRejectsInvalidLevel(t *testing.T) {
 		t.Fatal("runLogs() error = nil, want error for invalid level")
 	}
 }
+
+// TestRunLogsValidatesFlagsBeforeClientBuild pins that an invalid flag
+// combination reports the usage error without touching the kubeconfig/client
+// path, so a broken kube environment can't mask the real problem.
+func TestRunLogsValidatesFlagsBeforeClientBuild(t *testing.T) {
+	withClientFactory(t, func(kubernetes.ClientOptions) (k8skubernetes.Interface, string, error) {
+		t.Error("client factory should not be called when flag validation fails")
+		return nil, "", nil
+	})
+
+	var buf bytes.Buffer
+	err := executeLogs(&buf, "test-pod", "--timeline", "--follow")
+	if err == nil {
+		t.Fatal("runLogs() error = nil, want flag-combination error")
+	}
+	if !strings.Contains(err.Error(), "--timeline cannot be used with --follow") {
+		t.Fatalf("runLogs() error = %v, want the --timeline/--follow usage error", err)
+	}
+}

--- a/cmd/version.go
+++ b/cmd/version.go
@@ -55,11 +55,11 @@ func init() {
 	versionCmd.Flags().StringP(flagOutput, "o", "", "Output format (json or yaml)")
 }
 
-func getVersionData(version version.Version) versionData {
+func getVersionData(v version.Version) versionData {
 	return versionData{
-		Version:   version.String(),
-		Commit:    version.CommitHash,
-		BuildDate: version.BuildDate,
+		Version:   v.String(),
+		Commit:    v.CommitHash,
+		BuildDate: v.BuildDate,
 		GoVersion: runtime.Version(),
 		OS:        runtime.GOOS,
 		Arch:      runtime.GOARCH,
@@ -67,8 +67,14 @@ func getVersionData(version version.Version) versionData {
 }
 
 func runVersion(cmd *cobra.Command, args []string) error {
-	short, _ := cmd.Flags().GetBool(flagShort)
-	output, _ := cmd.Flags().GetString(flagOutput)
+	short, err := getBoolFlag(cmd, flagShort)
+	if err != nil {
+		return err
+	}
+	output, err := getStringFlag(cmd, flagOutput)
+	if err != nil {
+		return err
+	}
 
 	return writeVersion(cmd.OutOrStdout(), version.CurrentVersion, short, output)
 }

--- a/internal/kubernetes/container.go
+++ b/internal/kubernetes/container.go
@@ -8,7 +8,6 @@ import (
 	"github.com/dantech2000/logx/internal/terminal"
 	"github.com/fatih/color"
 	corev1 "k8s.io/api/core/v1"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
 )
 
@@ -124,9 +123,9 @@ func allContainerSpecs(pod *corev1.Pod) []containerSpec {
 
 // ListContainers returns detailed information about containers in a pod
 func ListContainers(ctx context.Context, clientset kubernetes.Interface, namespace, podName string) ([]ContainerInfo, error) {
-	pod, err := clientset.CoreV1().Pods(namespace).Get(ctx, podName, metav1.GetOptions{})
+	pod, err := fetchPod(ctx, clientset, namespace, podName)
 	if err != nil {
-		return nil, fmt.Errorf("error fetching pod details: %w", err)
+		return nil, err
 	}
 
 	statuses := make(map[string]corev1.ContainerStatus, len(pod.Status.ContainerStatuses)+

--- a/internal/kubernetes/container.go
+++ b/internal/kubernetes/container.go
@@ -4,6 +4,7 @@ package kubernetes
 import (
 	"context"
 	"fmt"
+	"slices"
 
 	"github.com/dantech2000/logx/internal/terminal"
 	"github.com/fatih/color"
@@ -161,10 +162,5 @@ func podContainerNames(pod *corev1.Pod) []string {
 // podHasContainer reports whether the pod defines a container with the given
 // name, including init and ephemeral containers (which also have fetchable logs).
 func podHasContainer(pod *corev1.Pod, name string) bool {
-	for _, s := range allContainerSpecs(pod) {
-		if s.name == name {
-			return true
-		}
-	}
-	return false
+	return slices.ContainsFunc(allContainerSpecs(pod), func(s containerSpec) bool { return s.name == name })
 }

--- a/internal/kubernetes/container_test.go
+++ b/internal/kubernetes/container_test.go
@@ -183,7 +183,7 @@ func TestGetLogsRejectsUnknownContainer(t *testing.T) {
 	}
 }
 
-func TestGetSingleContainerNameSingle(t *testing.T) {
+func TestSelectContainerNameSingle(t *testing.T) {
 	pod := &corev1.Pod{
 		ObjectMeta: metav1.ObjectMeta{Name: "solo", Namespace: "default"},
 		Spec:       corev1.PodSpec{Containers: []corev1.Container{{Name: "only", Image: "img"}}},
@@ -191,16 +191,20 @@ func TestGetSingleContainerNameSingle(t *testing.T) {
 	clientset := fake.NewSimpleClientset(pod)
 	fetcher := NewLogFetcher(clientset, "default", "solo", false, false, nil)
 
-	name, err := fetcher.getSingleContainerName(context.Background())
+	fetched, err := fetcher.getPod(context.Background())
 	if err != nil {
-		t.Fatalf("getSingleContainerName() error = %v", err)
+		t.Fatalf("getPod() error = %v", err)
+	}
+	name, err := fetcher.selectContainerName(fetched)
+	if err != nil {
+		t.Fatalf("selectContainerName() error = %v", err)
 	}
 	if name != "only" {
 		t.Fatalf("name = %q, want %q", name, "only")
 	}
 }
 
-func TestGetSingleContainerNameNoContainers(t *testing.T) {
+func TestSelectContainerNameNoContainers(t *testing.T) {
 	pod := &corev1.Pod{
 		ObjectMeta: metav1.ObjectMeta{Name: "empty", Namespace: "default"},
 		Spec:       corev1.PodSpec{},
@@ -208,17 +212,21 @@ func TestGetSingleContainerNameNoContainers(t *testing.T) {
 	clientset := fake.NewSimpleClientset(pod)
 	fetcher := NewLogFetcher(clientset, "default", "empty", false, false, nil)
 
-	if _, err := fetcher.getSingleContainerName(context.Background()); err == nil {
-		t.Fatal("getSingleContainerName() error = nil, want error for pod with no containers")
+	fetched, err := fetcher.getPod(context.Background())
+	if err != nil {
+		t.Fatalf("getPod() error = %v", err)
+	}
+	if _, err := fetcher.selectContainerName(fetched); err == nil {
+		t.Fatal("selectContainerName() error = nil, want error for pod with no containers")
 	}
 }
 
-func TestGetSingleContainerNameMissingPod(t *testing.T) {
+func TestGetPodMissingPod(t *testing.T) {
 	clientset := fake.NewSimpleClientset()
 	fetcher := NewLogFetcher(clientset, "default", "ghost", false, false, nil)
 
-	if _, err := fetcher.getSingleContainerName(context.Background()); err == nil {
-		t.Fatal("getSingleContainerName() error = nil, want error for missing pod")
+	if _, err := fetcher.getPod(context.Background()); err == nil {
+		t.Fatal("getPod() error = nil, want error for missing pod")
 	}
 }
 

--- a/internal/kubernetes/container_test.go
+++ b/internal/kubernetes/container_test.go
@@ -178,8 +178,14 @@ func TestGetLogsRejectsUnknownContainer(t *testing.T) {
 	fetcher := NewLogFetcher(clientset, "default", "p", false, false, &buf)
 	fetcher.ContainerName = "nope"
 
-	if err := fetcher.GetLogs(context.Background()); err == nil {
+	err := fetcher.GetLogs(context.Background())
+	if err == nil {
 		t.Fatal("GetLogs() with unknown container = nil error, want error")
+	}
+	// %q quoting pins that untrusted container/pod names are escaped in the
+	// error text rather than interpolated raw.
+	if !strings.Contains(err.Error(), `container "nope" not found in pod "p"`) {
+		t.Fatalf("GetLogs() error = %v, want %%q-quoted container/pod names", err)
 	}
 }
 

--- a/internal/kubernetes/enhancements_test.go
+++ b/internal/kubernetes/enhancements_test.go
@@ -80,10 +80,10 @@ func TestFanInStreamsBoundedPoolStreamsAll(t *testing.T) {
 	const limit = 2
 	const containers = 6
 
-	var opened int32
+	var opened atomic.Int32
 	clientset := fake.NewSimpleClientset()
 	clientset.PrependReactor("get", "pods/log", func(action clientgotesting.Action) (bool, runtime.Object, error) {
-		atomic.AddInt32(&opened, 1)
+		opened.Add(1)
 		ga := action.(clientgotesting.GenericAction)
 		opts := ga.GetValue().(*corev1.PodLogOptions)
 		return true, &runtime.Unknown{Raw: []byte("INFO line from " + opts.Container)}, nil
@@ -109,7 +109,7 @@ func TestFanInStreamsBoundedPoolStreamsAll(t *testing.T) {
 		t.Fatalf("GetAllContainerLogs error: %v", err)
 	}
 
-	if got := atomic.LoadInt32(&opened); int(got) != containers {
+	if got := opened.Load(); int(got) != containers {
 		t.Fatalf("opened %d streams, want all %d drained through the pool", got, containers)
 	}
 	if got := strings.Count(strings.TrimRight(buf.String(), "\n"), "\n") + 1; got != containers {

--- a/internal/kubernetes/logs.go
+++ b/internal/kubernetes/logs.go
@@ -203,10 +203,13 @@ func (lf *LogFetcher) GetLogs(ctx context.Context) error {
 
 	// Drive the shared pipeline over the stream, one line at a time.
 	pipeline := lf.newPipeline()
-	logWriter := NewLogWriterWithPipeline(lf.Writer, pipeline)
 	scanner := logging.NewLineReader(podLogs)
 	for scanner.Scan() {
-		if _, err := logWriter.Write([]byte(scanner.Text())); err != nil {
+		out, ok := pipeline.ProcessLine(scanner.Text())
+		if !ok {
+			continue
+		}
+		if _, err := fmt.Fprintln(lf.Writer, out); err != nil {
 			return fmt.Errorf("error writing log line: %w", err)
 		}
 	}

--- a/internal/kubernetes/logs.go
+++ b/internal/kubernetes/logs.go
@@ -149,7 +149,7 @@ func (lf *LogFetcher) previousContainerTerminated(pod *corev1.Pod, containerName
 			return status.RestartCount > 0, nil
 		}
 	}
-	return false, fmt.Errorf("container '%s' not found in pod '%s'", containerName, lf.PodName)
+	return false, fmt.Errorf("container %q not found in pod %q", containerName, lf.PodName)
 }
 
 // LogWriter is an io.Writer that feeds each written line through a shared

--- a/internal/kubernetes/logs.go
+++ b/internal/kubernetes/logs.go
@@ -193,29 +193,15 @@ func (lf *LogFetcher) GetLogs(ctx context.Context) error {
 		return err
 	}
 
-	podLogOpts := lf.podLogOptions(lf.ContainerName)
-	req := lf.Clientset.CoreV1().Pods(lf.Namespace).GetLogs(lf.PodName, &podLogOpts)
-	podLogs, err := req.Stream(ctx)
-	if err != nil {
-		return fmt.Errorf("error opening log stream: %w", err)
-	}
-	defer func() { _ = podLogs.Close() }()
-
-	// Drive the shared pipeline over the stream, one line at a time.
 	pipeline := lf.newPipeline()
-	scanner := logging.NewLineReader(podLogs)
-	for scanner.Scan() {
-		out, ok := pipeline.ProcessLine(scanner.Text())
-		if !ok {
-			continue
-		}
-		if _, err := fmt.Fprintln(lf.Writer, out); err != nil {
+	err := lf.streamLogs(ctx, lf.Namespace, lf.PodName, lf.ContainerName, pipeline, func(line string) error {
+		if _, err := fmt.Fprintln(lf.Writer, line); err != nil {
 			return fmt.Errorf("error writing log line: %w", err)
 		}
-	}
-
-	if err := scanner.Err(); err != nil {
-		return fmt.Errorf("error reading log stream: %w", err)
+		return nil
+	})
+	if err != nil {
+		return err
 	}
 
 	if stats := pipeline.Stats(); stats != nil {
@@ -223,6 +209,50 @@ func (lf *LogFetcher) GetLogs(ctx context.Context) error {
 	}
 
 	return nil
+}
+
+// streamLogs opens the log stream for one container and drives pipeline over it
+// line by line, calling emit for each rendered line. Shared by the single-stream
+// (GetLogs) and prefixed multi-stream (streamPrefixed) paths, which differ only
+// in how an emitted line is written.
+func (lf *LogFetcher) streamLogs(ctx context.Context, namespace, pod, container string, pipeline *logging.Pipeline, emit func(string) error) error {
+	opts := lf.podLogOptions(container)
+	req := lf.Clientset.CoreV1().Pods(namespace).GetLogs(pod, &opts)
+	stream, err := req.Stream(ctx)
+	if err != nil {
+		return fmt.Errorf("error opening log stream for %s/%s: %w", pod, container, err)
+	}
+	defer func() { _ = stream.Close() }()
+
+	scanner := logging.NewLineReader(stream)
+	for scanner.Scan() {
+		out, ok := pipeline.ProcessLine(scanner.Text())
+		if !ok {
+			continue
+		}
+		if err := emit(out); err != nil {
+			return err
+		}
+	}
+	if err := scanner.Err(); err != nil {
+		return fmt.Errorf("error reading log stream for %s/%s: %w", pod, container, err)
+	}
+	return nil
+}
+
+// fetchPod fetches a pod with the shared "error fetching pod details" wrapping
+// used by every pod lookup in this package.
+func fetchPod(ctx context.Context, clientset kubernetes.Interface, namespace, name string) (*corev1.Pod, error) {
+	pod, err := clientset.CoreV1().Pods(namespace).Get(ctx, name, metav1.GetOptions{})
+	if err != nil {
+		return nil, fmt.Errorf("error fetching pod details: %w", err)
+	}
+	return pod, nil
+}
+
+// getPod fetches the fetcher's own pod.
+func (lf *LogFetcher) getPod(ctx context.Context) (*corev1.Pod, error) {
+	return fetchPod(ctx, lf.Clientset, lf.Namespace, lf.PodName)
 }
 
 // podLogOptions builds the PodLogOptions for a container from the fetcher's
@@ -243,9 +273,7 @@ func (lf *LogFetcher) podLogOptions(container string) corev1.PodLogOptions {
 // newPipeline builds the shared logging pipeline from the fetcher's filters,
 // with the level taken authoritatively from FilterLevel.
 func (lf *LogFetcher) newPipeline() *logging.Pipeline {
-	opts := lf.Filters
-	opts.MinLevel = lf.FilterLevel
-	return logging.NewPipeline(opts)
+	return lf.newStreamPipeline(nil)
 }
 
 // newStreamPipeline builds a per-stream pipeline. When shared is non-nil the

--- a/internal/kubernetes/logs.go
+++ b/internal/kubernetes/logs.go
@@ -67,20 +67,9 @@ func NewLogFetcher(clientset kubernetes.Interface, namespace, podName string, fo
 	}
 }
 
-// getSingleContainerName returns the name of the container to fetch logs from.
-// If there's only one container, it returns that container's name.
-// If there are multiple containers, it prompts the user to select one.
-func (lf *LogFetcher) getSingleContainerName(ctx context.Context) (string, error) {
-	pod, err := lf.Clientset.CoreV1().Pods(lf.Namespace).Get(ctx, lf.PodName, metav1.GetOptions{})
-	if err != nil {
-		return "", fmt.Errorf("error fetching pod details: %w", err)
-	}
-	return lf.selectContainerName(pod)
-}
-
-// selectContainerName is the pure counterpart of getSingleContainerName: it
-// operates on an already-fetched pod so prepareLogRequest can reuse a single
-// Get call instead of fetching the pod again just to resolve the container name.
+// selectContainerName resolves the container to fetch logs from on an
+// already-fetched pod: the sole container's name when there is exactly one,
+// otherwise an interactive prompt to pick among them.
 func (lf *LogFetcher) selectContainerName(pod *corev1.Pod) (string, error) {
 	containerCount := len(pod.Spec.Containers)
 	switch containerCount {
@@ -131,18 +120,8 @@ func (lf *LogFetcher) selectContainerName(pod *corev1.Pod) (string, error) {
 	return containers[selectedIdx].Name, nil
 }
 
-// hasPreviousContainer checks if a container has previous terminated instances
-func (lf *LogFetcher) hasPreviousContainer(ctx context.Context, containerName string) (bool, error) {
-	pod, err := lf.Clientset.CoreV1().Pods(lf.Namespace).Get(ctx, lf.PodName, metav1.GetOptions{})
-	if err != nil {
-		return false, fmt.Errorf("error fetching pod details: %w", err)
-	}
-	return lf.previousContainerTerminated(pod, containerName)
-}
-
-// previousContainerTerminated is the pure counterpart of hasPreviousContainer:
-// it operates on an already-fetched pod so prepareLogRequest can reuse a single
-// Get call instead of fetching the pod again just to check restart history.
+// previousContainerTerminated reports, from an already-fetched pod, whether the
+// named container has restarted — i.e. whether --previous has logs to fetch.
 func (lf *LogFetcher) previousContainerTerminated(pod *corev1.Pod, containerName string) (bool, error) {
 	for _, status := range pod.Status.ContainerStatuses {
 		if status.Name == containerName {
@@ -150,39 +129,6 @@ func (lf *LogFetcher) previousContainerTerminated(pod *corev1.Pod, containerName
 		}
 	}
 	return false, fmt.Errorf("container %q not found in pod %q", containerName, lf.PodName)
-}
-
-// LogWriter is an io.Writer that feeds each written line through a shared
-// logging.Pipeline and writes the rendered result. It expects exactly one log
-// line per Write call (with no embedded newline), which is how GetLogs drives it
-// from the line reader; this per-line contract is also what lets later features
-// (multi-container / multi-pod) wrap one LogWriter per stream and merge them.
-type LogWriter struct {
-	writer   io.Writer
-	pipeline *logging.Pipeline
-}
-
-// Write implements io.Writer. p must be a single log line.
-func (w *LogWriter) Write(p []byte) (n int, err error) {
-	out, ok := w.pipeline.ProcessLine(string(p))
-	if !ok {
-		return len(p), nil
-	}
-	if _, err := fmt.Fprintln(w.writer, out); err != nil {
-		return len(p), err
-	}
-	return len(p), nil
-}
-
-// NewLogWriter creates a LogWriter that emits every entry at or above DEBUG.
-func NewLogWriter(w io.Writer) *LogWriter {
-	return NewLogWriterWithPipeline(w, logging.NewPipeline(logging.PipelineOptions{MinLevel: logging.DEBUG}))
-}
-
-// NewLogWriterWithPipeline creates a LogWriter backed by a caller-configured
-// Pipeline, so the filter level (and later, richer filters) is set in one place.
-func NewLogWriterWithPipeline(w io.Writer, pipeline *logging.Pipeline) *LogWriter {
-	return &LogWriter{writer: w, pipeline: pipeline}
 }
 
 // GetLogs retrieves logs from the specified container.

--- a/internal/kubernetes/logs_test.go
+++ b/internal/kubernetes/logs_test.go
@@ -1015,19 +1015,25 @@ func TestLogFetcher_hasPreviousContainer(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			fetcher := NewLogFetcher(clientset, "default", "test-pod", false, false, nil)
-			got, err := fetcher.hasPreviousContainer(context.Background(), tt.containerName)
+			fetchedPod, err := fetcher.getPod(context.Background())
+			if err != nil {
+				t.Fatalf("getPod() error = %v", err)
+			}
+			got, err := fetcher.previousContainerTerminated(fetchedPod, tt.containerName)
 			if (err != nil) != tt.wantError {
-				t.Errorf("hasPreviousContainer() error = %v, wantError %v", err, tt.wantError)
+				t.Errorf("previousContainerTerminated() error = %v, wantError %v", err, tt.wantError)
 				return
 			}
 			if got != tt.want {
-				t.Errorf("hasPreviousContainer() = %v, want %v", got, tt.want)
+				t.Errorf("previousContainerTerminated() = %v, want %v", got, tt.want)
 			}
 		})
 	}
 }
 
-func TestLogWriter_Write(t *testing.T) {
+// TestPipelineRendersKubeletLines pins how the pipeline (which GetLogs drives
+// line by line) renders representative kubelet-prefixed log lines.
+func TestPipelineRendersKubeletLines(t *testing.T) {
 	tests := []struct {
 		name     string
 		input    string
@@ -1057,43 +1063,31 @@ func TestLogWriter_Write(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			var buf bytes.Buffer
-			writer := NewLogWriter(&buf)
+			pipeline := logging.NewPipeline(logging.PipelineOptions{MinLevel: logging.DEBUG})
 
-			n, err := writer.Write([]byte(tt.input))
-			if err != nil {
-				t.Errorf("Write() error = %v", err)
-				return
+			got := ""
+			if out, ok := pipeline.ProcessLine(tt.input); ok {
+				got = out + "\n"
 			}
-
-			if n != len([]byte(tt.input)) {
-				t.Errorf("Write() wrote %v bytes, want %v", n, len([]byte(tt.input)))
-			}
-
-			if got := buf.String(); got != tt.wantLogs {
-				t.Errorf("Write() output = %q, want %q", got, tt.wantLogs)
+			if got != tt.wantLogs {
+				t.Errorf("ProcessLine() output = %q, want %q", got, tt.wantLogs)
 			}
 		})
 	}
 }
 
-func TestLogWriter_WriteFiltersByLevel(t *testing.T) {
-	var buf bytes.Buffer
-	writer := NewLogWriterWithPipeline(&buf, logging.NewPipeline(logging.PipelineOptions{MinLevel: logging.WARN}))
+func TestPipelineFiltersByLevel(t *testing.T) {
+	pipeline := logging.NewPipeline(logging.PipelineOptions{MinLevel: logging.WARN})
 
-	if _, err := writer.Write([]byte("2024-03-15T12:19:57Z INFO hidden")); err != nil {
-		t.Fatalf("Write() info error = %v", err)
+	if out, ok := pipeline.ProcessLine("2024-03-15T12:19:57Z INFO hidden"); ok {
+		t.Fatalf("ProcessLine() kept filtered log: %q", out)
 	}
-	if _, err := writer.Write([]byte("2024-03-15T12:19:57Z ERROR shown")); err != nil {
-		t.Fatalf("Write() error error = %v", err)
+	out, ok := pipeline.ProcessLine("2024-03-15T12:19:57Z ERROR shown")
+	if !ok {
+		t.Fatal("ProcessLine() dropped log above the filter level")
 	}
-
-	got := buf.String()
-	if strings.Contains(got, "hidden") {
-		t.Fatalf("Write() included filtered log: %q", got)
-	}
-	if !strings.Contains(got, "shown") {
-		t.Fatalf("Write() missing expected log: %q", got)
+	if !strings.Contains(out, "shown") {
+		t.Fatalf("ProcessLine() missing expected log: %q", out)
 	}
 }
 

--- a/internal/kubernetes/multistream.go
+++ b/internal/kubernetes/multistream.go
@@ -19,9 +19,9 @@ import (
 // serialized so lines never interleave mid-line. It returns the first stream
 // error, if any, after all streams finish.
 func (lf *LogFetcher) GetAllContainerLogs(ctx context.Context) error {
-	pod, err := lf.Clientset.CoreV1().Pods(lf.Namespace).Get(ctx, lf.PodName, metav1.GetOptions{})
+	pod, err := lf.getPod(ctx)
 	if err != nil {
-		return fmt.Errorf("error fetching pod details: %w", err)
+		return err
 	}
 	names := podContainerNames(pod)
 	if len(names) == 0 {
@@ -181,26 +181,10 @@ func (lf *LogFetcher) effectiveMaxConcurrency(streamCount int) int {
 // the pipeline records into it instead of producing per-line output, so --stats
 // aggregates across every stream.
 func (lf *LogFetcher) streamPrefixed(ctx context.Context, s prefixedStream, mu *sync.Mutex, shared *logging.Stats) error {
-	opts := lf.podLogOptions(s.container)
-	req := lf.Clientset.CoreV1().Pods(s.namespace).GetLogs(s.pod, &opts)
-	stream, err := req.Stream(ctx)
-	if err != nil {
-		return fmt.Errorf("error opening log stream for %s/%s: %w", s.pod, s.container, err)
-	}
-	defer func() { _ = stream.Close() }()
-
 	pipeline := lf.newStreamPipeline(shared)
-	scanner := logging.NewLineReader(stream)
-	for scanner.Scan() {
-		out, ok := pipeline.ProcessLine(scanner.Text())
-		if !ok {
-			continue
-		}
-		if err := writeLine(mu, lf.Writer, s.prefix, out); err != nil {
-			return err
-		}
-	}
-	return scanner.Err()
+	return lf.streamLogs(ctx, s.namespace, s.pod, s.container, pipeline, func(line string) error {
+		return writeLine(mu, lf.Writer, s.prefix, line)
+	})
 }
 
 // writeLine writes "prefix + line + newline" as a single guarded write so

--- a/internal/kubernetes/multistream.go
+++ b/internal/kubernetes/multistream.go
@@ -166,13 +166,7 @@ func (lf *LogFetcher) effectiveMaxConcurrency(streamCount int) int {
 	if limit <= 0 {
 		limit = defaultMaxConcurrency
 	}
-	if limit > streamCount {
-		limit = streamCount
-	}
-	if limit < 1 {
-		limit = 1
-	}
-	return limit
+	return max(1, min(limit, streamCount))
 }
 
 // streamPrefixed reads one container's logs through a private pipeline and writes

--- a/internal/kubernetes/timeline.go
+++ b/internal/kubernetes/timeline.go
@@ -134,7 +134,7 @@ func (lf *LogFetcher) prepareLogRequest(ctx context.Context) (*corev1.Pod, error
 	}
 
 	if !podHasContainer(pod, lf.ContainerName) {
-		return nil, fmt.Errorf("container '%s' not found in pod '%s'", lf.ContainerName, lf.PodName)
+		return nil, fmt.Errorf("container %q not found in pod %q", lf.ContainerName, lf.PodName)
 	}
 
 	if lf.Previous {
@@ -143,7 +143,7 @@ func (lf *LogFetcher) prepareLogRequest(ctx context.Context) (*corev1.Pod, error
 			return nil, fmt.Errorf("failed to check for previous container: %w", err)
 		}
 		if !hasPrevious {
-			return nil, fmt.Errorf("no previous terminated container found for '%s' in pod '%s'\nNote: The -p flag only works for containers that have terminated or restarted",
+			return nil, fmt.Errorf("no previous terminated container found for %q in pod %q\nNote: The -p flag only works for containers that have terminated or restarted",
 				lf.ContainerName, lf.PodName)
 		}
 	}

--- a/internal/kubernetes/timeline.go
+++ b/internal/kubernetes/timeline.go
@@ -120,9 +120,9 @@ func (lf *LogFetcher) GetTimeline(ctx context.Context) error {
 // returning the pod so callers with further pod-shaped work (e.g. GetTimeline's
 // termination lookup) don't need to fetch it again.
 func (lf *LogFetcher) prepareLogRequest(ctx context.Context) (*corev1.Pod, error) {
-	pod, err := lf.Clientset.CoreV1().Pods(lf.Namespace).Get(ctx, lf.PodName, metav1.GetOptions{})
+	pod, err := lf.getPod(ctx)
 	if err != nil {
-		return nil, fmt.Errorf("error fetching pod details: %w", err)
+		return nil, err
 	}
 
 	if lf.ContainerName == "" {
@@ -369,17 +369,16 @@ func formatTimelineEvent(event timelineEvent) string {
 	if event.Count > 1 {
 		message = fmt.Sprintf("%s (x%d)", message, event.Count)
 	}
+	// event.Object was sanitized when built (formatEventObject); it contributes
+	// an optional segment between the type and the reason.
+	object := ""
 	if event.Object != "" {
-		return fmt.Sprintf("%s [EVENT] [%s] %s %s: %s",
-			formatTimelineTimestamp(event.Timestamp),
-			formatTimelineEventType(event),
-			event.Object,
-			terminal.Sanitize(event.Reason),
-			message)
+		object = " " + event.Object
 	}
-	return fmt.Sprintf("%s [EVENT] [%s] %s: %s",
+	return fmt.Sprintf("%s [EVENT] [%s]%s %s: %s",
 		formatTimelineTimestamp(event.Timestamp),
 		formatTimelineEventType(event),
+		object,
 		terminal.Sanitize(event.Reason),
 		message)
 }
@@ -421,5 +420,5 @@ func formatTimelineTimestamp(timestamp time.Time) string {
 	if timestamp.IsZero() {
 		return "[no timestamp]"
 	}
-	return fmt.Sprintf("[%s]", timestamp.UTC().Format("2006-01-02 15:04:05"))
+	return fmt.Sprintf("[%s]", timestamp.UTC().Format(logging.DisplayTimeLayout))
 }

--- a/internal/kubernetes/timeline.go
+++ b/internal/kubernetes/timeline.go
@@ -3,7 +3,7 @@ package kubernetes
 import (
 	"context"
 	"fmt"
-	"sort"
+	"slices"
 	"strings"
 	"time"
 
@@ -29,7 +29,6 @@ const (
 
 type timelineItem struct {
 	timestamp time.Time
-	order     int
 	line      string
 }
 
@@ -56,12 +55,8 @@ func (lf *LogFetcher) GetTimeline(ctx context.Context) error {
 		return err
 	}
 
-	items, err := lf.collectLogTimelineItems(ctx)
-	logErr := err
-	if err != nil {
-		items = nil
-	}
-	eventItems, eventsTruncated, err := lf.collectEventTimelineItems(ctx, len(items))
+	items, logErr := lf.collectLogTimelineItems(ctx)
+	eventItems, eventsTruncated, err := lf.collectEventTimelineItems(ctx)
 	if err != nil {
 		return err
 	}
@@ -73,7 +68,7 @@ func (lf *LogFetcher) GetTimeline(ctx context.Context) error {
 	// Container termination details (exit code, OOMKilled, signal) explain why a
 	// container died — something the events don't spell out. Reuses the pod
 	// fetched by prepareLogRequest instead of fetching it again.
-	items = append(items, lf.collectTerminationItems(pod, len(items))...)
+	items = append(items, lf.collectTerminationItems(pod)...)
 
 	// Logs failed but events are available: degrade gracefully (events often
 	// explain why logs are missing, e.g. ImagePullBackOff) while still telling
@@ -90,21 +85,20 @@ func (lf *LogFetcher) GetTimeline(ctx context.Context) error {
 		}
 	}
 
-	sort.SliceStable(items, func(i, j int) bool {
-		left, right := items[i], items[j]
-		if left.timestamp.IsZero() && right.timestamp.IsZero() {
-			return left.order < right.order
+	// Items were appended in a meaningful order (logs, then events, then
+	// terminations, each group in its own order), so a stable sort by timestamp
+	// alone keeps that order for equal keys; zero timestamps sort last.
+	slices.SortStableFunc(items, func(a, b timelineItem) int {
+		switch {
+		case a.timestamp.IsZero() && b.timestamp.IsZero():
+			return 0
+		case a.timestamp.IsZero():
+			return 1
+		case b.timestamp.IsZero():
+			return -1
+		default:
+			return a.timestamp.Compare(b.timestamp)
 		}
-		if left.timestamp.IsZero() {
-			return false
-		}
-		if right.timestamp.IsZero() {
-			return true
-		}
-		if left.timestamp.Equal(right.timestamp) {
-			return left.order < right.order
-		}
-		return left.timestamp.Before(right.timestamp)
 	})
 
 	for _, item := range items {
@@ -182,7 +176,6 @@ func (lf *LogFetcher) collectLogTimelineItems(ctx context.Context) ([]timelineIt
 		}
 		items = append(items, timelineItem{
 			timestamp: entry.Timestamp,
-			order:     len(items),
 			line:      formatTimelineLog(entry),
 		})
 	}
@@ -194,7 +187,7 @@ func (lf *LogFetcher) collectLogTimelineItems(ctx context.Context) ([]timelineIt
 
 // collectEventTimelineItems returns the timeline items for this pod's events and
 // reports whether the server-side list was truncated by the result limit.
-func (lf *LogFetcher) collectEventTimelineItems(ctx context.Context, orderOffset int) ([]timelineItem, bool, error) {
+func (lf *LogFetcher) collectEventTimelineItems(ctx context.Context) ([]timelineItem, bool, error) {
 	// Scope the server-side query to events for this pod: this avoids reading the
 	// whole namespace's events (which leaks unrelated workloads, needs broad RBAC,
 	// and floods the timeline) and bounds the result size.
@@ -217,7 +210,6 @@ func (lf *LogFetcher) collectEventTimelineItems(ctx context.Context, orderOffset
 		timelineEvent := newTimelineEvent(event)
 		items = append(items, timelineItem{
 			timestamp: timelineEvent.Timestamp,
-			order:     orderOffset + len(items),
 			line:      formatTimelineEvent(timelineEvent),
 		})
 	}
@@ -230,17 +222,17 @@ func (lf *LogFetcher) collectEventTimelineItems(ctx context.Context, orderOffset
 // target container — the current termination (if the container has exited) and
 // the previous instance's termination (from LastTerminationState) — carrying the
 // exit code, reason (e.g. OOMKilled), and signal.
-func (lf *LogFetcher) collectTerminationItems(pod *corev1.Pod, orderOffset int) []timelineItem {
+func (lf *LogFetcher) collectTerminationItems(pod *corev1.Pod) []timelineItem {
 	var items []timelineItem
 	for _, cs := range allContainerStatuses(pod) {
 		if cs.Name != lf.ContainerName {
 			continue
 		}
 		if t := cs.LastTerminationState.Terminated; t != nil {
-			items = append(items, terminationTimelineItem(*t, cs.Name, true, orderOffset+len(items)))
+			items = append(items, terminationTimelineItem(*t, cs.Name, true))
 		}
 		if t := cs.State.Terminated; t != nil {
-			items = append(items, terminationTimelineItem(*t, cs.Name, false, orderOffset+len(items)))
+			items = append(items, terminationTimelineItem(*t, cs.Name, false))
 		}
 	}
 	return items
@@ -257,10 +249,9 @@ func allContainerStatuses(pod *corev1.Pod) []corev1.ContainerStatus {
 	return statuses
 }
 
-func terminationTimelineItem(term corev1.ContainerStateTerminated, container string, previous bool, order int) timelineItem {
+func terminationTimelineItem(term corev1.ContainerStateTerminated, container string, previous bool) timelineItem {
 	return timelineItem{
 		timestamp: term.FinishedAt.Time,
-		order:     order,
 		line:      formatTermination(term, container, previous),
 	}
 }

--- a/internal/logging/adversarial_test.go
+++ b/internal/logging/adversarial_test.go
@@ -143,7 +143,7 @@ func FuzzPipelineAllFeatures(f *testing.F) {
 			opts.Output = OutputJSON
 		}
 		// One line at a time (the scanner guarantees no embedded newlines).
-		for _, line := range strings.Split(data, "\n") {
+		for line := range strings.SplitSeq(data, "\n") {
 			out, ok := NewPipeline(opts).ProcessLine(line)
 			if !ok {
 				continue

--- a/internal/logging/continuation.go
+++ b/internal/logging/continuation.go
@@ -6,8 +6,9 @@ import "regexp"
 // exactly one separating space. Unlike kubernetesTimestampPrefixRegex (which uses
 // \s+ and therefore swallows the payload's own leading whitespace), this matches
 // only the single separator, so the content's indentation is preserved for
-// continuation detection.
-var kubeletTimestampSepRegex = regexp.MustCompile(`^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:\.\d+)?Z `)
+// continuation detection. The timestamp core is shared via kubeletTimestampPattern
+// (parser.go).
+var kubeletTimestampSepRegex = regexp.MustCompile(`^` + kubeletTimestampPattern + ` `)
 
 // payloadIndented reports whether the log content carried by rawLine begins with
 // whitespace (a space or tab). It first removes an optional kubelet timestamp

--- a/internal/logging/format.go
+++ b/internal/logging/format.go
@@ -116,7 +116,7 @@ func FormatLogEntry(entry LogEntry) string {
 
 // FormatLogLevelLabel returns the colorized bracketed label for a log level.
 func FormatLogLevelLabel(level LogLevel) string {
-	return levelColorFor(level).Sprint(fmt.Sprintf("[%s]", level))
+	return levelColorFor(level).Sprintf("[%s]", level)
 }
 
 // prefixPalette colors stream labels (container/pod names) in merged output. The
@@ -145,49 +145,43 @@ func ColorizePrefix(label string, idx int) string {
 // (level, message, logger, timestamp) are supported alongside structured fields;
 // a missing key is omitted so output stays composable.
 func FormatProjectedEntry(entry LogEntry, fields []string) string {
+	return formatProjectedEntry(entry, classifyFields(fields))
+}
+
+// formatProjectedEntry is FormatProjectedEntry over pre-classified keys, the
+// form the pipeline uses so the virtual-key groups are not re-scanned per line.
+func formatProjectedEntry(entry LogEntry, fields []projectedField) string {
 	parts := make([]string, 0, len(fields))
 	for _, f := range fields {
 		val, ok := projectFieldValue(entry, f)
 		if !ok {
 			continue
 		}
-		parts = append(parts, fmt.Sprintf("%s=%s", keyColor().Sprint(terminal.Sanitize(f)), val))
+		parts = append(parts, fmt.Sprintf("%s=%s", keyColor().Sprint(terminal.Sanitize(f.key)), val))
 	}
 	return strings.Join(parts, " ")
 }
 
 // projectFieldValue returns the formatted value for a projection key, or false
 // when the entry has nothing for it.
-func projectFieldValue(entry LogEntry, key string) (string, bool) {
-	switch {
-	case keyIn(key, levelKeys):
+func projectFieldValue(entry LogEntry, f projectedField) (string, bool) {
+	if f.kind == fieldKindLevel {
 		return levelColorFor(entry.Level).Sprint(entry.Level.String()), true
-	case keyIn(key, messageKeys):
-		msg := entry.Message
-		if msg == "" {
-			msg = entry.RawLine
-		}
-		if msg == "" {
-			return "", false
-		}
-		return formatStringValue(msg), true
-	case keyIn(key, loggerKeys):
-		if entry.Logger == "" {
-			return "", false
-		}
-		return valueColor().Sprint(terminal.Sanitize(entry.Logger)), true
-	case keyIn(key, tsKeys):
-		if entry.Timestamp.IsZero() {
-			return "", false
-		}
+	}
+	raw, ok := resolveByKind(entry, f.kind, f.key)
+	if !ok {
+		return "", false
+	}
+	switch f.kind {
+	case fieldKindMessage:
+		return formatStringValue(stringValue(raw)), true
+	case fieldKindLogger:
+		return valueColor().Sprint(terminal.Sanitize(stringValue(raw))), true
+	case fieldKindTimestamp:
 		return timestampColor().Sprint(entry.Timestamp.UTC().Format("2006-01-02 15:04:05")), true
+	default:
+		return formatValue(raw), true
 	}
-	if entry.Fields != nil {
-		if v, ok := fieldValue(entry.Fields, key); ok {
-			return formatValue(v), true
-		}
-	}
-	return "", false
 }
 
 // FormatLogEntryDetails renders the message and structured fields of an entry,

--- a/internal/logging/format.go
+++ b/internal/logging/format.go
@@ -4,6 +4,7 @@ import (
 	"cmp"
 	"encoding/json"
 	"fmt"
+	"maps"
 	"regexp"
 	"slices"
 	"strings"
@@ -267,7 +268,7 @@ func containsAttentionText(value string) bool {
 		strings.Contains(lowerValue, "warn")
 }
 
-func formatSortedFields(fields map[string]interface{}) []string {
+func formatSortedFields(fields map[string]any) []string {
 	formattedFields := make([]string, 0, len(fields))
 	for _, key := range sortedKeys(fields) {
 		if jsonFormattedFieldExclusions[key] || isJSONMessageField(key) {
@@ -284,16 +285,11 @@ func isJSONMessageField(field string) bool {
 	return jsonMessageFieldSet[field]
 }
 
-func sortedKeys(data map[string]interface{}) []string {
-	keys := make([]string, 0, len(data))
-	for key := range data {
-		keys = append(keys, key)
-	}
-	slices.Sort(keys)
-	return keys
+func sortedKeys(data map[string]any) []string {
+	return slices.Sorted(maps.Keys(data))
 }
 
-func formatValue(v interface{}) string {
+func formatValue(v any) string {
 	switch val := v.(type) {
 	case string:
 		return formatStringValue(val)
@@ -315,7 +311,7 @@ func formatValue(v interface{}) string {
 		return formatJSONNumber(val)
 	case int, int8, int16, int32, int64, uint, uint8, uint16, uint32, uint64:
 		return valueColor().Sprintf("%d", val)
-	case map[string]interface{}:
+	case map[string]any:
 		parts := make([]string, 0, len(val))
 		for _, key := range sortedKeys(val) {
 			parts = append(parts, fmt.Sprintf("%s=%s",
@@ -323,7 +319,7 @@ func formatValue(v interface{}) string {
 				formatValue(val[key])))
 		}
 		return fmt.Sprintf("{%s}", strings.Join(parts, " "))
-	case []interface{}:
+	case []any:
 		parts := make([]string, 0, len(val))
 		for _, item := range val {
 			parts = append(parts, formatValue(item))

--- a/internal/logging/format.go
+++ b/internal/logging/format.go
@@ -4,7 +4,6 @@ import (
 	"cmp"
 	"encoding/json"
 	"fmt"
-	"maps"
 	"regexp"
 	"slices"
 	"strings"
@@ -146,16 +145,10 @@ func ColorizePrefix(label string, idx int) string {
 	return prefixPalette[idx%len(prefixPalette)].Sprint(terminal.Sanitize(label))
 }
 
-// FormatProjectedEntry renders only the requested keys of an entry as
-// `key=value` pairs in the given order (the --fields projection). Virtual keys
-// (level, message, logger, timestamp) are supported alongside structured fields;
-// a missing key is omitted so output stays composable.
-func FormatProjectedEntry(entry LogEntry, fields []string) string {
-	return formatProjectedEntry(entry, classifyFields(fields))
-}
-
-// formatProjectedEntry is FormatProjectedEntry over pre-classified keys, the
-// form the pipeline uses so the virtual-key groups are not re-scanned per line.
+// formatProjectedEntry renders only the requested (pre-classified) keys of an
+// entry as `key=value` pairs in the given order (the --fields projection).
+// Virtual keys (level, message, logger, timestamp) are supported alongside
+// structured fields; a missing key is omitted so output stays composable.
 func formatProjectedEntry(entry LogEntry, fields []projectedField) string {
 	parts := make([]string, 0, len(fields))
 	for _, f := range fields {
@@ -169,10 +162,18 @@ func formatProjectedEntry(entry LogEntry, fields []projectedField) string {
 }
 
 // projectFieldValue returns the formatted value for a projection key, or false
-// when the entry has nothing for it.
+// when the entry has nothing for it. Level and timestamp render from the
+// entry's typed fields directly (colorized name, display layout); the rest
+// resolve through resolveByKind like the predicate engine.
 func projectFieldValue(entry LogEntry, f projectedField) (string, bool) {
-	if f.kind == fieldKindLevel {
+	switch f.kind {
+	case fieldKindLevel:
 		return levelColorFor(entry.Level).Sprint(entry.Level.String()), true
+	case fieldKindTimestamp:
+		if entry.Timestamp.IsZero() {
+			return "", false
+		}
+		return timestampColor().Sprint(entry.Timestamp.UTC().Format(DisplayTimeLayout)), true
 	}
 	raw, ok := resolveByKind(entry, f.kind, f.key)
 	if !ok {
@@ -183,8 +184,6 @@ func projectFieldValue(entry LogEntry, f projectedField) (string, bool) {
 		return formatStringValue(stringValue(raw)), true
 	case fieldKindLogger:
 		return valueColor().Sprint(terminal.Sanitize(stringValue(raw))), true
-	case fieldKindTimestamp:
-		return timestampColor().Sprint(entry.Timestamp.UTC().Format(DisplayTimeLayout)), true
 	default:
 		return formatValue(raw), true
 	}
@@ -285,8 +284,15 @@ func isJSONMessageField(field string) bool {
 	return jsonMessageFieldSet[field]
 }
 
+// sortedKeys deliberately avoids slices.Sorted(maps.Keys(...)): the iterator
+// form cannot pre-size from the map length, and this runs per rendered line.
 func sortedKeys(data map[string]any) []string {
-	return slices.Sorted(maps.Keys(data))
+	keys := make([]string, 0, len(data))
+	for key := range data {
+		keys = append(keys, key)
+	}
+	slices.Sort(keys)
+	return keys
 }
 
 func formatValue(v any) string {

--- a/internal/logging/format.go
+++ b/internal/logging/format.go
@@ -20,6 +20,11 @@ const (
 	highlightOff = "\x1b[27m"
 )
 
+// DisplayTimeLayout is the human-readable timestamp layout used consistently
+// across normal output, the --fields projection, --stats, and --timeline, so
+// the columns of the different views line up.
+const DisplayTimeLayout = "2006-01-02 15:04:05"
+
 // highlightMatches wraps every non-overlapping match of any pattern in s with
 // reverse-video so grep matches stand out. Overlapping match ranges from
 // different patterns are merged. It is a no-op when color is disabled, so plain
@@ -98,7 +103,7 @@ func FormatLogEntry(entry LogEntry) string {
 		// Normalize to UTC so timestamps are consistent regardless of the source
 		// format (RFC3339 parses to UTC, but epoch values parse to local time);
 		// this also matches the --timeline output.
-		b.WriteString(timestampColor().Sprintf("[%s]", entry.Timestamp.UTC().Format("2006-01-02 15:04:05")))
+		b.WriteString(timestampColor().Sprintf("[%s]", entry.Timestamp.UTC().Format(DisplayTimeLayout)))
 		b.WriteByte(' ')
 	}
 
@@ -178,7 +183,7 @@ func projectFieldValue(entry LogEntry, f projectedField) (string, bool) {
 	case fieldKindLogger:
 		return valueColor().Sprint(terminal.Sanitize(stringValue(raw))), true
 	case fieldKindTimestamp:
-		return timestampColor().Sprint(entry.Timestamp.UTC().Format("2006-01-02 15:04:05")), true
+		return timestampColor().Sprint(entry.Timestamp.UTC().Format(DisplayTimeLayout)), true
 	default:
 		return formatValue(raw), true
 	}
@@ -242,10 +247,8 @@ func formatPlainTextDetails(entry LogEntry) string {
 }
 
 func jsonMessage(entry LogEntry) string {
-	for _, field := range jsonMessageFields {
-		if val, ok := entry.Fields[field]; ok {
-			return terminal.Sanitize(fmt.Sprintf("%v", val))
-		}
+	if s, ok := firstStringField(entry.Fields, jsonMessageFields...); ok {
+		return terminal.Sanitize(s)
 	}
 	return ""
 }

--- a/internal/logging/format_test.go
+++ b/internal/logging/format_test.go
@@ -16,7 +16,7 @@ func TestFormatLogEntryDetailsDeterministicJSONFields(t *testing.T) {
 	entry := ParseLogEntry(`{"message":"done","zeta":1,"alpha":"first","nested":{"z":2,"a":1},"level":"info","loglevel":"ignored","time":"2026-05-20T20:37:54Z","ts":1779309485}`)
 
 	first := FormatLogEntryDetails(entry)
-	for i := 0; i < 20; i++ {
+	for range 20 {
 		if got := FormatLogEntryDetails(entry); got != first {
 			t.Fatalf("FormatLogEntryDetails changed between runs: first=%q got=%q", first, got)
 		}
@@ -38,9 +38,9 @@ func TestFormatLogEntryDetailsDeterministicJSONFields(t *testing.T) {
 func TestFormatLogEntryDetailsFormatsArraysAndNumbers(t *testing.T) {
 	entry := LogEntry{
 		Format: FormatJSON,
-		Fields: map[string]interface{}{
+		Fields: map[string]any{
 			"message": "batch complete",
-			"ids":     []interface{}{float64(3), "two", true},
+			"ids":     []any{float64(3), "two", true},
 			"count":   int64(7),
 			"ratio":   float32(1.5),
 		},

--- a/internal/logging/format_test.go
+++ b/internal/logging/format_test.go
@@ -194,12 +194,12 @@ func TestFormatProjectedEntry(t *testing.T) {
 	ApplyColorMode(ColorNever)
 
 	entry := ParseLogEntry(`{"level":"error","msg":"db down","status":500,"time":"2026-06-24T10:00:00Z"}`)
-	out := FormatProjectedEntry(entry, []string{"level", "status", "msg", "missing"})
+	out := formatProjectedEntry(entry, classifyFields([]string{"level", "status", "msg", "missing"}))
 
 	// Requested keys appear in order; the missing key is omitted.
 	want := `level=ERROR status=500 msg="db down"`
 	if out != want {
-		t.Fatalf("FormatProjectedEntry = %q, want %q", out, want)
+		t.Fatalf("formatProjectedEntry = %q, want %q", out, want)
 	}
 }
 
@@ -207,8 +207,8 @@ func TestFormatProjectedEntryTimestampVirtualKey(t *testing.T) {
 	restoreColor(t)
 	ApplyColorMode(ColorNever)
 	entry := ParseLogEntry(`{"msg":"hi","ts":"2026-06-24T10:00:00Z"}`)
-	out := FormatProjectedEntry(entry, []string{"ts", "msg"})
+	out := formatProjectedEntry(entry, classifyFields([]string{"ts", "msg"}))
 	if out != `ts=2026-06-24 10:00:00 msg=hi` {
-		t.Fatalf("FormatProjectedEntry ts = %q", out)
+		t.Fatalf("formatProjectedEntry ts = %q", out)
 	}
 }

--- a/internal/logging/levels.go
+++ b/internal/logging/levels.go
@@ -35,3 +35,13 @@ func (l LogLevel) String() string {
 		return "UNKNOWN"
 	}
 }
+
+// LevelNames lists every level name in ascending severity order. Exported so
+// help text and shell completion (cmd) derive from the same set the parser
+// accepts instead of hardcoding their own copies.
+func LevelNames() []string {
+	return []string{
+		TRACE.String(), DEBUG.String(), INFO.String(),
+		WARN.String(), ERROR.String(), FATAL.String(),
+	}
+}

--- a/internal/logging/output_json.go
+++ b/internal/logging/output_json.go
@@ -71,10 +71,16 @@ func MarshalEntryJSON(entry LogEntry) string {
 // MarshalProjectedJSON renders only the requested keys as a flat JSON object,
 // the JSON counterpart of the --fields projection.
 func MarshalProjectedJSON(entry LogEntry, fields []string) string {
+	return marshalProjectedJSON(entry, classifyFields(fields))
+}
+
+// marshalProjectedJSON is MarshalProjectedJSON over pre-classified keys, the
+// form the pipeline uses so the virtual-key groups are not re-scanned per line.
+func marshalProjectedJSON(entry LogEntry, fields []projectedField) string {
 	obj := make(map[string]interface{}, len(fields))
 	for _, f := range fields {
 		if v, ok := projectRawValue(entry, f); ok {
-			obj[f] = v
+			obj[f.key] = v
 		}
 	}
 	return marshalLine(obj)
@@ -100,12 +106,12 @@ func extraFields(fields map[string]interface{}) map[string]interface{} {
 }
 
 // projectRawValue returns the raw value for a projection key, handling the level
-// virtual key (which resolveField leaves to the predicate engine).
-func projectRawValue(entry LogEntry, key string) (interface{}, bool) {
-	if keyIn(key, levelKeys) {
+// virtual key (which resolveByKind leaves to the predicate engine).
+func projectRawValue(entry LogEntry, f projectedField) (interface{}, bool) {
+	if f.kind == fieldKindLevel {
 		return entry.Level.String(), true
 	}
-	return resolveField(entry, key)
+	return resolveByKind(entry, f.kind, f.key)
 }
 
 func marshalLine(v interface{}) string {

--- a/internal/logging/output_json.go
+++ b/internal/logging/output_json.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"strings"
+	"time"
 )
 
 // OutputFormat selects how the pipeline renders each kept entry.
@@ -39,12 +40,12 @@ var formatNames = map[LogFormat]string{
 // jsonEntry is the normalized shape emitted by --output json. It is intentionally
 // stable so downstream tooling can rely on it regardless of the source format.
 type jsonEntry struct {
-	Time    string                 `json:"time,omitempty"`
-	Level   string                 `json:"level"`
-	Logger  string                 `json:"logger,omitempty"`
-	Message string                 `json:"message,omitempty"`
-	Format  string                 `json:"format"`
-	Fields  map[string]interface{} `json:"fields,omitempty"`
+	Time    string         `json:"time,omitempty"`
+	Level   string         `json:"level"`
+	Logger  string         `json:"logger,omitempty"`
+	Message string         `json:"message,omitempty"`
+	Format  string         `json:"format"`
+	Fields  map[string]any `json:"fields,omitempty"`
 }
 
 // MarshalEntryJSON renders a parsed entry as a single normalized JSON object.
@@ -63,7 +64,7 @@ func MarshalEntryJSON(entry LogEntry) string {
 		out.Message = ""
 	}
 	if !entry.Timestamp.IsZero() {
-		out.Time = entry.Timestamp.UTC().Format("2006-01-02T15:04:05Z07:00")
+		out.Time = entry.Timestamp.UTC().Format(time.RFC3339)
 	}
 	return marshalLine(out)
 }
@@ -77,7 +78,7 @@ func MarshalProjectedJSON(entry LogEntry, fields []string) string {
 // marshalProjectedJSON is MarshalProjectedJSON over pre-classified keys, the
 // form the pipeline uses so the virtual-key groups are not re-scanned per line.
 func marshalProjectedJSON(entry LogEntry, fields []projectedField) string {
-	obj := make(map[string]interface{}, len(fields))
+	obj := make(map[string]any, len(fields))
 	for _, f := range fields {
 		if v, ok := projectRawValue(entry, f); ok {
 			obj[f.key] = v
@@ -88,11 +89,11 @@ func marshalProjectedJSON(entry LogEntry, fields []projectedField) string {
 
 // extraFields returns the structured fields minus the ones already surfaced as
 // dedicated columns (level/time/message), so JSON output isn't redundant.
-func extraFields(fields map[string]interface{}) map[string]interface{} {
+func extraFields(fields map[string]any) map[string]any {
 	if len(fields) == 0 {
 		return nil
 	}
-	out := make(map[string]interface{}, len(fields))
+	out := make(map[string]any, len(fields))
 	for k, v := range fields {
 		if jsonFormattedFieldExclusions[k] || isJSONMessageField(k) {
 			continue
@@ -107,14 +108,14 @@ func extraFields(fields map[string]interface{}) map[string]interface{} {
 
 // projectRawValue returns the raw value for a projection key, handling the level
 // virtual key (which resolveByKind leaves to the predicate engine).
-func projectRawValue(entry LogEntry, f projectedField) (interface{}, bool) {
+func projectRawValue(entry LogEntry, f projectedField) (any, bool) {
 	if f.kind == fieldKindLevel {
 		return entry.Level.String(), true
 	}
 	return resolveByKind(entry, f.kind, f.key)
 }
 
-func marshalLine(v interface{}) string {
+func marshalLine(v any) string {
 	b, err := json.Marshal(v)
 	if err != nil {
 		return "{}"

--- a/internal/logging/output_json.go
+++ b/internal/logging/output_json.go
@@ -69,18 +69,12 @@ func MarshalEntryJSON(entry LogEntry) string {
 	return marshalLine(out)
 }
 
-// MarshalProjectedJSON renders only the requested keys as a flat JSON object,
-// the JSON counterpart of the --fields projection.
-func MarshalProjectedJSON(entry LogEntry, fields []string) string {
-	return marshalProjectedJSON(entry, classifyFields(fields))
-}
-
-// marshalProjectedJSON is MarshalProjectedJSON over pre-classified keys, the
-// form the pipeline uses so the virtual-key groups are not re-scanned per line.
+// marshalProjectedJSON renders only the requested (pre-classified) keys as a
+// flat JSON object, the JSON counterpart of the --fields projection.
 func marshalProjectedJSON(entry LogEntry, fields []projectedField) string {
 	obj := make(map[string]any, len(fields))
 	for _, f := range fields {
-		if v, ok := projectRawValue(entry, f); ok {
+		if v, ok := resolveByKind(entry, f.kind, f.key); ok {
 			obj[f.key] = v
 		}
 	}
@@ -104,15 +98,6 @@ func extraFields(fields map[string]any) map[string]any {
 		return nil
 	}
 	return out
-}
-
-// projectRawValue returns the raw value for a projection key, handling the level
-// virtual key (which resolveByKind leaves to the predicate engine).
-func projectRawValue(entry LogEntry, f projectedField) (any, bool) {
-	if f.kind == fieldKindLevel {
-		return entry.Level.String(), true
-	}
-	return resolveByKind(entry, f.kind, f.key)
 }
 
 func marshalLine(v any) string {

--- a/internal/logging/output_json_test.go
+++ b/internal/logging/output_json_test.go
@@ -66,7 +66,7 @@ func TestMarshalProjectedJSON(t *testing.T) {
 		ParseLogEntry(`{"level":"warn","status":404,"path":"/x","msg":"nope"}`),
 		[]string{"level", "status", "missing"},
 	)
-	var obj map[string]interface{}
+	var obj map[string]any
 	if err := json.Unmarshal([]byte(out), &obj); err != nil {
 		t.Fatalf("invalid JSON: %v (%s)", err, out)
 	}

--- a/internal/logging/output_json_test.go
+++ b/internal/logging/output_json_test.go
@@ -62,9 +62,9 @@ func TestMarshalEntryJSONEscapesControlBytes(t *testing.T) {
 }
 
 func TestMarshalProjectedJSON(t *testing.T) {
-	out := MarshalProjectedJSON(
+	out := marshalProjectedJSON(
 		ParseLogEntry(`{"level":"warn","status":404,"path":"/x","msg":"nope"}`),
-		[]string{"level", "status", "missing"},
+		classifyFields([]string{"level", "status", "missing"}),
 	)
 	var obj map[string]any
 	if err := json.Unmarshal([]byte(out), &obj); err != nil {

--- a/internal/logging/parser.go
+++ b/internal/logging/parser.go
@@ -114,8 +114,14 @@ var logParsers = []logParser{
 	csvLogParser{},
 }
 
+// kubeletTimestampPattern is the RFC3339 shape of a kubelet --timestamps prefix.
+// It is the shared core of kubernetesTimestampPrefixRegex (below) and
+// kubeletTimestampSepRegex (continuation.go) so the two cannot drift; they
+// intentionally differ only in the separator they consume.
+const kubeletTimestampPattern = `\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:\.\d+)?Z`
+
 var (
-	kubernetesTimestampPrefixRegex = regexp.MustCompile(`^(\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:\.\d+)?Z)\s+(.*)$`)
+	kubernetesTimestampPrefixRegex = regexp.MustCompile(`^(` + kubeletTimestampPattern + `)\s+(.*)$`)
 	plainTextTimestampRegex        = regexp.MustCompile(`\d{4}[-/]\d{2}[-/]\d{2}[T ]\d{2}:\d{2}:\d{2}(?:\.\d+)?(?:Z|[+-]\d{2}:?\d{2})?`)
 	plainTextLevelRegex            = regexp.MustCompile(`(?i)(^|[^[:alnum:]_])(DEBUG|INFO|WARN(?:ING)?|ERROR|FATAL|TRACE)([^[:alnum:]_]|$)`)
 	// logfmtKeyRegex matches identifier-like logfmt keys so that tokens such as a
@@ -400,8 +406,7 @@ func parseJSONLog(line string, data map[string]interface{}) LogEntry {
 func parseJSONLevel(data map[string]interface{}) (LogLevel, bool) {
 	for _, field := range jsonLevelFields {
 		if val, ok := fieldValue(data, field); ok {
-			levelStr := fmt.Sprintf("%v", val)
-			if level, err := ParseLogLevel(levelStr); err == nil {
+			if level, err := ParseLogLevel(stringValue(val)); err == nil {
 				return level, true
 			}
 		}
@@ -415,12 +420,12 @@ func parseJSONLevel(data map[string]interface{}) (LogLevel, bool) {
 func parseJSONMessage(line string, data map[string]interface{}) string {
 	for _, field := range jsonMessageFields {
 		if val, ok := fieldValue(data, field); ok {
-			return fmt.Sprintf("%v", val)
+			return stringValue(val)
 		}
 	}
 
 	if err, ok := data["error"]; ok {
-		return fmt.Sprintf("%v", err)
+		return stringValue(err)
 	}
 	return line
 }
@@ -488,23 +493,8 @@ func parseHTTPStatusLevel(data map[string]interface{}) (LogLevel, bool) {
 		return DEBUG, false
 	}
 
-	var status int
-	switch value := statusValue.(type) {
-	case float64:
-		status = int(value)
-	case json.Number:
-		parsedStatus, err := strconv.Atoi(value.String())
-		if err != nil {
-			return DEBUG, false
-		}
-		status = parsedStatus
-	case string:
-		parsedStatus, err := strconv.Atoi(strings.TrimSpace(value))
-		if err != nil {
-			return DEBUG, false
-		}
-		status = parsedStatus
-	default:
+	status, ok := toInt(statusValue)
+	if !ok {
 		return DEBUG, false
 	}
 

--- a/internal/logging/parser.go
+++ b/internal/logging/parser.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"regexp"
+	"slices"
 	"strconv"
 	"strings"
 	"time"
@@ -26,7 +27,7 @@ type LogEntry struct {
 	Message   string
 	Format    LogFormat
 	Logger    string
-	Fields    map[string]interface{}
+	Fields    map[string]any
 	Timestamp time.Time
 	RawLine   string // Original payload used as fallback display text.
 	// LevelDetected reports whether Level came from the line itself (an explicit
@@ -166,7 +167,7 @@ func (jsonLogParser) Parse(line string) (LogEntry, bool) {
 		return LogEntry{}, false
 	}
 
-	var data map[string]interface{}
+	var data map[string]any
 	decoder := json.NewDecoder(strings.NewReader(trimmedLine))
 	decoder.UseNumber()
 	if err := decoder.Decode(&data); err != nil {
@@ -354,7 +355,7 @@ func klogLevel(letter string) LogLevel {
 }
 
 // detectLoggerLabel returns a display label for known structured logging formats.
-func detectLoggerLabel(data map[string]interface{}) string {
+func detectLoggerLabel(data map[string]any) string {
 	switch {
 	case data["caller"] != nil && data["ts"] != nil:
 		return "zap"
@@ -385,7 +386,7 @@ func parseTimestamp(timeStr string) (time.Time, error) {
 	return time.Time{}, fmt.Errorf("unable to parse time: %s", timeStr)
 }
 
-func parseJSONLog(line string, data map[string]interface{}) LogEntry {
+func parseJSONLog(line string, data map[string]any) LogEntry {
 	logger := detectLoggerLabel(data)
 	entry := LogEntry{
 		Format:  FormatJSON,
@@ -403,7 +404,7 @@ func parseJSONLog(line string, data map[string]interface{}) LogEntry {
 // parseJSONLevel resolves the level from a JSON log object and reports whether a
 // level was actually found (via a level field or HTTP status) rather than
 // defaulted to DEBUG.
-func parseJSONLevel(data map[string]interface{}) (LogLevel, bool) {
+func parseJSONLevel(data map[string]any) (LogLevel, bool) {
 	for _, field := range jsonLevelFields {
 		if val, ok := fieldValue(data, field); ok {
 			if level, err := ParseLogLevel(stringValue(val)); err == nil {
@@ -417,7 +418,7 @@ func parseJSONLevel(data map[string]interface{}) (LogLevel, bool) {
 	return DEBUG, false
 }
 
-func parseJSONMessage(line string, data map[string]interface{}) string {
+func parseJSONMessage(line string, data map[string]any) string {
 	for _, field := range jsonMessageFields {
 		if val, ok := fieldValue(data, field); ok {
 			return stringValue(val)
@@ -430,7 +431,7 @@ func parseJSONMessage(line string, data map[string]interface{}) string {
 	return line
 }
 
-func parseJSONTimestamp(data map[string]interface{}) time.Time {
+func parseJSONTimestamp(data map[string]any) time.Time {
 	for _, field := range jsonTimeFields {
 		if val, ok := fieldValue(data, field); ok {
 			if numTime, ok := val.(float64); ok {
@@ -483,7 +484,7 @@ func parseUnixTimestampString(value string) (time.Time, bool) {
 	return parseUnixTimestamp(timestamp), true
 }
 
-func parseHTTPStatusLevel(data map[string]interface{}) (LogLevel, bool) {
+func parseHTTPStatusLevel(data map[string]any) (LogLevel, bool) {
 	if !hasHTTPContext(data) {
 		return DEBUG, false
 	}
@@ -519,14 +520,14 @@ func statusClassLevel(status int) (LogLevel, bool) {
 	}
 }
 
-func hasHTTPContext(data map[string]interface{}) bool {
+func hasHTTPContext(data map[string]any) bool {
 	return hasAnyField(data, httpContextFields)
 }
 
 // hasAnyField reports whether data has a value for any of keys, dot-path aware
 // (e.g. "request.method" walks into a nested map). Shared by hasHTTPContext and
 // the XML/CSV format detectors so both use the same field-presence semantics.
-func hasAnyField(data map[string]interface{}, keys []string) bool {
+func hasAnyField(data map[string]any, keys []string) bool {
 	for _, key := range keys {
 		if _, ok := fieldValue(data, key); ok {
 			return true
@@ -602,7 +603,7 @@ func stripPrefixToken(s, tok string) string {
 	return s
 }
 
-func splitTrailingFields(message string) (string, map[string]interface{}) {
+func splitTrailingFields(message string) (string, map[string]any) {
 	// Fast path: without a '=' there can be no key=value fields, so skip the
 	// tokenization (this runs for every bracketed line).
 	if !strings.Contains(message, "=") {
@@ -610,16 +611,16 @@ func splitTrailingFields(message string) (string, map[string]interface{}) {
 	}
 
 	parts := strings.Fields(message)
-	var fields map[string]interface{}
+	var fields map[string]any
 	fieldStart := len(parts)
 
-	for i := len(parts) - 1; i >= 0; i-- {
-		key, value, ok := simpleField(parts[i])
+	for i, part := range slices.Backward(parts) {
+		key, value, ok := simpleField(part)
 		if !ok {
 			break
 		}
 		if fields == nil {
-			fields = make(map[string]interface{})
+			fields = make(map[string]any)
 		}
 		fields[key] = strings.Trim(value, `"`)
 		fieldStart = i
@@ -647,8 +648,8 @@ func simpleField(value string) (key, fieldValue string, ok bool) {
 	return key, fieldValue, true
 }
 
-func parseLogfmtFields(line string) (map[string]interface{}, bool) {
-	fields := make(map[string]interface{})
+func parseLogfmtFields(line string) (map[string]any, bool) {
+	fields := make(map[string]any)
 	i := 0
 
 	for i < len(line) {
@@ -701,7 +702,7 @@ func parseLogfmtFields(line string) (map[string]interface{}, bool) {
 	return fields, len(fields) > 0
 }
 
-func firstStringField(fields map[string]interface{}, names ...string) (string, bool) {
+func firstStringField(fields map[string]any, names ...string) (string, bool) {
 	for _, name := range names {
 		if value, ok := fields[name]; ok {
 			return stringValue(value), true
@@ -713,14 +714,14 @@ func firstStringField(fields map[string]interface{}, names ...string) (string, b
 // stringValue returns v's string form, skipping the fmt machinery for the
 // common case where the value already is a string (logfmt and XML parsers only
 // ever produce string values; JSON messages usually are strings too).
-func stringValue(v interface{}) string {
+func stringValue(v any) string {
 	if s, ok := v.(string); ok {
 		return s
 	}
 	return fmt.Sprintf("%v", v)
 }
 
-func firstField(fields map[string]interface{}, names ...string) (interface{}, bool) {
+func firstField(fields map[string]any, names ...string) (any, bool) {
 	for _, name := range names {
 		if value, ok := fieldValue(fields, name); ok {
 			return value, true
@@ -729,7 +730,7 @@ func firstField(fields map[string]interface{}, names ...string) (interface{}, bo
 	return nil, false
 }
 
-func fieldValue(fields map[string]interface{}, name string) (interface{}, bool) {
+func fieldValue(fields map[string]any, name string) (any, bool) {
 	if value, ok := fields[name]; ok {
 		return value, true
 	}
@@ -740,11 +741,11 @@ func fieldValue(fields map[string]interface{}, name string) (interface{}, bool) 
 		return nil, false
 	}
 
-	current := interface{}(fields)
+	current := any(fields)
 	rest := name
 	for {
 		part, remainder, more := strings.Cut(rest, ".")
-		currentFields, ok := current.(map[string]interface{})
+		currentFields, ok := current.(map[string]any)
 		if !ok {
 			return nil, false
 		}

--- a/internal/logging/parser.go
+++ b/internal/logging/parser.go
@@ -613,14 +613,23 @@ func stripPrefixToken(s, tok string) string {
 }
 
 func splitTrailingFields(message string) (string, map[string]interface{}) {
+	// Fast path: without a '=' there can be no key=value fields, so skip the
+	// tokenization (this runs for every bracketed line).
+	if !strings.Contains(message, "=") {
+		return strings.TrimSpace(message), nil
+	}
+
 	parts := strings.Fields(message)
-	fields := make(map[string]interface{})
+	var fields map[string]interface{}
 	fieldStart := len(parts)
 
 	for i := len(parts) - 1; i >= 0; i-- {
 		key, value, ok := simpleField(parts[i])
 		if !ok {
 			break
+		}
+		if fields == nil {
+			fields = make(map[string]interface{})
 		}
 		fields[key] = strings.Trim(value, `"`)
 		fieldStart = i
@@ -705,10 +714,20 @@ func parseLogfmtFields(line string) (map[string]interface{}, bool) {
 func firstStringField(fields map[string]interface{}, names ...string) (string, bool) {
 	for _, name := range names {
 		if value, ok := fields[name]; ok {
-			return fmt.Sprintf("%v", value), true
+			return stringValue(value), true
 		}
 	}
 	return "", false
+}
+
+// stringValue returns v's string form, skipping the fmt machinery for the
+// common case where the value already is a string (logfmt and XML parsers only
+// ever produce string values; JSON messages usually are strings too).
+func stringValue(v interface{}) string {
+	if s, ok := v.(string); ok {
+		return s
+	}
+	return fmt.Sprintf("%v", v)
 }
 
 func firstField(fields map[string]interface{}, names ...string) (interface{}, bool) {
@@ -724,9 +743,17 @@ func fieldValue(fields map[string]interface{}, name string) (interface{}, bool) 
 	if value, ok := fields[name]; ok {
 		return value, true
 	}
+	// Only a dotted name can still resolve, as a path into nested maps. This
+	// runs on every probe of a missing key (level/message/time candidates,
+	// --where, --fields), so avoid any allocation on the miss path.
+	if !strings.Contains(name, ".") {
+		return nil, false
+	}
 
 	current := interface{}(fields)
-	for _, part := range strings.Split(name, ".") {
+	rest := name
+	for {
+		part, remainder, more := strings.Cut(rest, ".")
 		currentFields, ok := current.(map[string]interface{})
 		if !ok {
 			return nil, false
@@ -736,8 +763,11 @@ func fieldValue(fields map[string]interface{}, name string) (interface{}, bool) 
 			return nil, false
 		}
 		current = value
+		if !more {
+			return current, true
+		}
+		rest = remainder
 	}
-	return current, true
 }
 
 // ParseLogEntry parses a single log line, trying each known format parser in

--- a/internal/logging/parser_formats.go
+++ b/internal/logging/parser_formats.go
@@ -22,7 +22,7 @@ func (yamlFlowParser) Parse(line string) (LogEntry, bool) {
 	if !strings.HasPrefix(trimmed, "{") || !strings.HasSuffix(trimmed, "}") {
 		return LogEntry{}, false
 	}
-	var data map[string]interface{}
+	var data map[string]any
 	if err := yaml.Unmarshal([]byte(trimmed), &data); err != nil || len(data) == 0 {
 		return LogEntry{}, false
 	}
@@ -61,7 +61,7 @@ func (xmlLogParser) Parse(line string) (LogEntry, bool) {
 		return LogEntry{}, false
 	}
 
-	fields := make(map[string]interface{})
+	fields := make(map[string]any)
 	for _, a := range xmlAttrRegex.FindAllStringSubmatch(attrPart, -1) {
 		fields[a[1]] = a[2]
 	}

--- a/internal/logging/parser_formats_test.go
+++ b/internal/logging/parser_formats_test.go
@@ -106,3 +106,31 @@ func TestNewFormatsDoNotMisclassifyProse(t *testing.T) {
 		})
 	}
 }
+
+// TestYAMLFlowStatusFieldLevel pins that a YAML flow-map access log — whose
+// status value parses as a Go int, unlike JSON's float64 — classifies by HTTP
+// status exactly like the equivalent JSON line (5xx→ERROR, 4xx→WARN, 2xx→DEBUG
+// per statusClassLevel). This alignment arrived when parseHTTPStatusLevel
+// started coercing through toInt, which accepts int.
+func TestYAMLFlowStatusFieldLevel(t *testing.T) {
+	tests := []struct {
+		name      string
+		input     string
+		wantLevel LogLevel
+	}{
+		{"server error", `{status: 500, method: GET, path: /api, msg: upstream failed}`, ERROR},
+		{"client error", `{status: 404, method: GET, path: /missing, msg: not found}`, WARN},
+		{"success stays at DEBUG", `{status: 200, method: GET, path: /healthz, msg: ok}`, DEBUG},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := ParseLogEntry(tt.input)
+			if got.Level != tt.wantLevel {
+				t.Errorf("Level = %v, want %v", got.Level, tt.wantLevel)
+			}
+			if !got.LevelDetected {
+				t.Error("LevelDetected = false, want true (level derived from HTTP status)")
+			}
+		})
+	}
+}

--- a/internal/logging/parser_test.go
+++ b/internal/logging/parser_test.go
@@ -58,7 +58,7 @@ func TestParseLogEntry(t *testing.T) {
 				Message: "Server started",
 				Format:  FormatJSON,
 				Logger:  "logrus",
-				Fields: map[string]interface{}{
+				Fields: map[string]any{
 					"level": "info",
 					"msg":   "Server started",
 					"time":  "2024-03-15T12:19:57Z",
@@ -74,7 +74,7 @@ func TestParseLogEntry(t *testing.T) {
 				Message: "Failed to process request",
 				Format:  FormatJSON,
 				Logger:  "zap",
-				Fields: map[string]interface{}{
+				Fields: map[string]any{
 					"level":  "error",
 					"ts":     json.Number("1647340797"),
 					"caller": "api/handler.go:42",
@@ -635,12 +635,12 @@ func TestParseLogLevel(t *testing.T) {
 func TestDetectLogger(t *testing.T) {
 	tests := []struct {
 		name     string
-		input    map[string]interface{}
+		input    map[string]any
 		expected string
 	}{
 		{
 			name: "Zap logger",
-			input: map[string]interface{}{
+			input: map[string]any{
 				"caller": "main.go:42",
 				"ts":     1647340797,
 			},
@@ -648,7 +648,7 @@ func TestDetectLogger(t *testing.T) {
 		},
 		{
 			name: "Bunyan logger",
-			input: map[string]interface{}{
+			input: map[string]any{
 				"@level":     "info",
 				"@timestamp": "2024-03-15T12:19:57Z",
 			},
@@ -656,7 +656,7 @@ func TestDetectLogger(t *testing.T) {
 		},
 		{
 			name: "Logrus logger",
-			input: map[string]interface{}{
+			input: map[string]any{
 				"level": "info",
 				"msg":   "test message",
 			},
@@ -664,7 +664,7 @@ func TestDetectLogger(t *testing.T) {
 		},
 		{
 			name: "Unknown logger",
-			input: map[string]interface{}{
+			input: map[string]any{
 				"custom": "field",
 			},
 			expected: "",

--- a/internal/logging/pipeline.go
+++ b/internal/logging/pipeline.go
@@ -18,9 +18,31 @@ import (
 // kept or dropped as a unit. It is therefore NOT safe for concurrent use; create
 // one Pipeline per log stream.
 type Pipeline struct {
-	opts    PipelineOptions
+	opts PipelineOptions
+	// fields is opts.Fields with each key's fieldKind classified once at
+	// construction, so the per-line projection renderers don't re-scan the
+	// virtual-key groups for every field on every line.
+	fields  []projectedField
 	tracker LevelTracker
 	stats   *Stats
+}
+
+// projectedField pairs a --fields projection key with its precomputed kind.
+type projectedField struct {
+	key  string
+	kind fieldKind
+}
+
+// classifyFields classifies each projection key once.
+func classifyFields(keys []string) []projectedField {
+	if len(keys) == 0 {
+		return nil
+	}
+	out := make([]projectedField, len(keys))
+	for i, k := range keys {
+		out[i] = projectedField{key: k, kind: classifyKey(k)}
+	}
+	return out
 }
 
 // PipelineOptions configures a Pipeline. The zero value emits every non-blank
@@ -51,7 +73,7 @@ type PipelineOptions struct {
 
 // NewPipeline returns a Pipeline configured by opts.
 func NewPipeline(opts PipelineOptions) *Pipeline {
-	p := &Pipeline{opts: opts}
+	p := &Pipeline{opts: opts, fields: classifyFields(opts.Fields)}
 	if opts.CollectStats {
 		p.stats = NewStats()
 	}
@@ -66,7 +88,7 @@ func NewPipeline(opts PipelineOptions) *Pipeline {
 // mode.
 func NewPipelineWithStats(opts PipelineOptions, stats *Stats) *Pipeline {
 	opts.CollectStats = true
-	return &Pipeline{opts: opts, stats: stats}
+	return &Pipeline{opts: opts, fields: classifyFields(opts.Fields), stats: stats}
 }
 
 // Stats returns the accumulated digest, or nil if CollectStats was not set.
@@ -123,15 +145,15 @@ func (p *Pipeline) keep(entry LogEntry, rawLine string) bool {
 // applied last so it works in both modes.
 func (p *Pipeline) render(entry LogEntry) string {
 	if p.opts.Output == OutputJSON {
-		if len(p.opts.Fields) > 0 {
-			return MarshalProjectedJSON(entry, p.opts.Fields)
+		if len(p.fields) > 0 {
+			return marshalProjectedJSON(entry, p.fields)
 		}
 		return MarshalEntryJSON(entry)
 	}
 
 	var out string
-	if len(p.opts.Fields) > 0 {
-		out = FormatProjectedEntry(entry, p.opts.Fields)
+	if len(p.fields) > 0 {
+		out = formatProjectedEntry(entry, p.fields)
 	} else {
 		out = FormatLogEntry(entry)
 	}

--- a/internal/logging/predicate.go
+++ b/internal/logging/predicate.go
@@ -4,6 +4,7 @@ import (
 	"cmp"
 	"fmt"
 	"regexp"
+	"slices"
 	"strconv"
 	"strings"
 	"time"
@@ -20,12 +21,7 @@ var (
 )
 
 func keyIn(key string, set []string) bool {
-	for _, k := range set {
-		if strings.EqualFold(key, k) {
-			return true
-		}
-	}
-	return false
+	return slices.ContainsFunc(set, func(k string) bool { return strings.EqualFold(key, k) })
 }
 
 // fieldKind classifies a predicate's key once (at parse time) into one of the
@@ -277,7 +273,7 @@ func (fp FieldPredicate) evalLevel(level LogLevel) bool {
 // resolved here: the predicate engine compares levels by severity and the
 // projections render them specially, so a level kind falls through to the
 // structured-field lookup like any other plain key.
-func resolveByKind(entry LogEntry, kind fieldKind, key string) (interface{}, bool) {
+func resolveByKind(entry LogEntry, kind fieldKind, key string) (any, bool) {
 	switch kind {
 	case fieldKindMessage:
 		if entry.Message != "" {
@@ -304,6 +300,6 @@ func resolveByKind(entry LogEntry, kind fieldKind, key string) (interface{}, boo
 // resolveValue resolves the predicate's key against an entry, dispatching on
 // the key's precomputed kind instead of re-scanning the virtual-key groups on
 // every call, which matters here since Eval runs once per predicate per log line.
-func (fp FieldPredicate) resolveValue(entry LogEntry) (interface{}, bool) {
+func (fp FieldPredicate) resolveValue(entry LogEntry) (any, bool) {
 	return resolveByKind(entry, fp.kind, fp.key)
 }

--- a/internal/logging/predicate.go
+++ b/internal/logging/predicate.go
@@ -141,18 +141,20 @@ func ParseFieldPredicate(expr string) (FieldPredicate, error) {
 	return fp, nil
 }
 
-// operatorRunes are the characters that make up the comparison/match operators.
-// A field key composed solely of these is a parsing artifact, not a real name.
-const operatorRunes = "<>=!~"
+// PredicateOperatorChars are the characters that make up the --where
+// comparison/match operators. Exported so shell completion (cmd) can detect
+// when the user has moved past the field name without duplicating the set.
+const PredicateOperatorChars = "<>=!~"
 
 // isPureOperatorKey reports whether key is non-empty and made up entirely of
-// operator characters, e.g. ">" left over from parsing ">=5".
+// operator characters, e.g. ">" left over from parsing ">=5". Such a key is a
+// parsing artifact, not a real field name.
 func isPureOperatorKey(key string) bool {
 	if key == "" {
 		return false
 	}
 	for _, r := range key {
-		if !strings.ContainsRune(operatorRunes, r) {
+		if !strings.ContainsRune(PredicateOperatorChars, r) {
 			return false
 		}
 	}

--- a/internal/logging/predicate.go
+++ b/internal/logging/predicate.go
@@ -90,13 +90,15 @@ var predicateTokens = []struct {
 // string form against a regex. The key "level" (and lvl/severity) compares by
 // severity order, so `level>=WARN` works.
 type FieldPredicate struct {
-	key    string
-	op     predicateOp
-	val    string
-	num    float64
-	hasNum bool
-	re     *regexp.Regexp
-	kind   fieldKind
+	key      string
+	op       predicateOp
+	val      string
+	num      float64
+	hasNum   bool
+	level    LogLevel
+	hasLevel bool
+	re       *regexp.Regexp
+	kind     fieldKind
 }
 
 // ParseFieldPredicate parses an expression like "status>=500", "path~=/api", or
@@ -129,6 +131,11 @@ func ParseFieldPredicate(expr string) (FieldPredicate, error) {
 	default:
 		if n, err := strconv.ParseFloat(val, 64); err == nil {
 			fp.num, fp.hasNum = n, true
+		}
+		if fp.kind == fieldKindLevel {
+			if lvl, err := ParseLogLevel(val); err == nil {
+				fp.level, fp.hasLevel = lvl, true
+			}
 		}
 	}
 	return fp, nil
@@ -181,7 +188,7 @@ func (fp FieldPredicate) Eval(entry LogEntry) bool {
 		// A missing field is "not equal" to any value, and fails every other test.
 		return fp.op == opNeq
 	}
-	str := fmt.Sprintf("%v", raw)
+	str := stringValue(raw)
 
 	switch fp.op {
 	case opMatch:
@@ -242,14 +249,14 @@ func (fp FieldPredicate) compareNumeric(str string) bool {
 }
 
 // evalLevel compares against the entry's level by severity order, so
-// `level>=WARN` and `level==ERROR` both work. A numeric or unknown value falls
-// back to comparing the level name.
+// `level>=WARN` and `level==ERROR` both work. The wanted level is parsed once
+// at ParseFieldPredicate time; a value that never parsed as a level falls back
+// to comparing the level name.
 func (fp FieldPredicate) evalLevel(level LogLevel) bool {
 	if fp.op == opMatch {
 		return fp.re.MatchString(level.String())
 	}
-	want, err := ParseLogLevel(fp.val)
-	if err != nil {
+	if !fp.hasLevel {
 		switch fp.op {
 		case opEq:
 			return strings.EqualFold(level.String(), fp.val)
@@ -259,40 +266,17 @@ func (fp FieldPredicate) evalLevel(level LogLevel) bool {
 			return false
 		}
 	}
-	return compareOrdered(fp.op, level, want)
+	return compareOrdered(fp.op, level, fp.level)
 }
 
-// resolveField returns the raw value for a key, handling the virtual keys
-// (message/logger/timestamp) before falling back to a structured field
-// (dot-path aware).
-func resolveField(entry LogEntry, key string) (interface{}, bool) {
-	switch {
-	case keyIn(key, messageKeys):
-		if entry.Message != "" {
-			return entry.Message, true
-		}
-		return entry.RawLine, entry.RawLine != ""
-	case keyIn(key, loggerKeys):
-		return entry.Logger, entry.Logger != ""
-	case keyIn(key, tsKeys):
-		if entry.Timestamp.IsZero() {
-			return nil, false
-		}
-		return entry.Timestamp.UTC().Format(time.RFC3339), true
-	}
-	if entry.Fields != nil {
-		if v, ok := fieldValue(entry.Fields, key); ok {
-			return v, true
-		}
-	}
-	return nil, false
-}
-
-// resolveValue is resolveField's counterpart for a FieldPredicate: it dispatches
-// on the key's precomputed kind instead of re-scanning the virtual-key groups on
-// every call, which matters here since Eval runs once per predicate per log line.
-func (fp FieldPredicate) resolveValue(entry LogEntry) (interface{}, bool) {
-	switch fp.kind {
+// resolveByKind returns the raw value for a key already classified into a
+// fieldKind, handling the virtual keys (message/logger/timestamp) before
+// falling back to a structured field (dot-path aware). Level keys are not
+// resolved here: the predicate engine compares levels by severity and the
+// projections render them specially, so a level kind falls through to the
+// structured-field lookup like any other plain key.
+func resolveByKind(entry LogEntry, kind fieldKind, key string) (interface{}, bool) {
+	switch kind {
 	case fieldKindMessage:
 		if entry.Message != "" {
 			return entry.Message, true
@@ -307,10 +291,17 @@ func (fp FieldPredicate) resolveValue(entry LogEntry) (interface{}, bool) {
 		return entry.Timestamp.UTC().Format(time.RFC3339), true
 	default:
 		if entry.Fields != nil {
-			if v, ok := fieldValue(entry.Fields, fp.key); ok {
+			if v, ok := fieldValue(entry.Fields, key); ok {
 				return v, true
 			}
 		}
 		return nil, false
 	}
+}
+
+// resolveValue resolves the predicate's key against an entry, dispatching on
+// the key's precomputed kind instead of re-scanning the virtual-key groups on
+// every call, which matters here since Eval runs once per predicate per log line.
+func (fp FieldPredicate) resolveValue(entry LogEntry) (interface{}, bool) {
+	return resolveByKind(entry, fp.kind, fp.key)
 }

--- a/internal/logging/predicate.go
+++ b/internal/logging/predicate.go
@@ -268,13 +268,14 @@ func (fp FieldPredicate) evalLevel(level LogLevel) bool {
 }
 
 // resolveByKind returns the raw value for a key already classified into a
-// fieldKind, handling the virtual keys (message/logger/timestamp) before
-// falling back to a structured field (dot-path aware). Level keys are not
-// resolved here: the predicate engine compares levels by severity and the
-// projections render them specially, so a level kind falls through to the
-// structured-field lookup like any other plain key.
+// fieldKind, handling the virtual keys (level/message/logger/timestamp) before
+// falling back to a structured field (dot-path aware). A level kind resolves to
+// the parsed level's name; the predicate engine never asks for it (Eval routes
+// level keys to evalLevel for severity-ordered comparison first).
 func resolveByKind(entry LogEntry, kind fieldKind, key string) (any, bool) {
 	switch kind {
+	case fieldKindLevel:
+		return entry.Level.String(), true
 	case fieldKindMessage:
 		if entry.Message != "" {
 			return entry.Message, true

--- a/internal/logging/scanner.go
+++ b/internal/logging/scanner.go
@@ -54,14 +54,11 @@ func (lr *LineReader) Scan() bool {
 			if err == nil { // frag includes the trailing '\n'
 				chunk = frag[:len(frag)-1]
 			}
-			if room := MaxLogLineSize - b.Len(); room > 0 {
-				if len(chunk) > room {
-					b.Write(chunk[:room])
-					truncated = true
-				} else {
-					b.Write(chunk)
-				}
-			} else if len(chunk) > 0 {
+			// Keep at most the room left under MaxLogLineSize; anything beyond
+			// it is dropped and the line marked truncated.
+			keep := min(len(chunk), max(MaxLogLineSize-b.Len(), 0))
+			b.Write(chunk[:keep])
+			if keep < len(chunk) {
 				truncated = true
 			}
 		}

--- a/internal/logging/stats.go
+++ b/internal/logging/stats.go
@@ -144,9 +144,11 @@ func (s *Stats) Write(w io.Writer) error {
 	fmt.Fprintln(&b, quoteColor().Sprint("── logx stats ──"))
 	fmt.Fprintf(&b, "lines: %d", s.total)
 	if !s.firstTS.IsZero() {
+		// firstTS/lastTS were normalized to UTC by Record, matching the other
+		// DisplayTimeLayout renderings.
 		fmt.Fprintf(&b, "   span: %s → %s",
-			s.firstTS.Format("2006-01-02 15:04:05"),
-			s.lastTS.Format("2006-01-02 15:04:05"))
+			s.firstTS.Format(DisplayTimeLayout),
+			s.lastTS.Format(DisplayTimeLayout))
 	}
 	fmt.Fprintln(&b)
 

--- a/internal/logging/stats.go
+++ b/internal/logging/stats.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"maps"
 	"regexp"
 	"slices"
 	"strconv"
@@ -116,7 +117,7 @@ func statusClassOf(entry LogEntry) (int, bool) {
 	return status / 100, true
 }
 
-func toInt(v interface{}) (int, bool) {
+func toInt(v any) (int, bool) {
 	switch n := v.(type) {
 	case float64:
 		return int(n), true
@@ -177,11 +178,7 @@ func (s *Stats) writeStatusClasses(b *strings.Builder) {
 	if len(s.statusClass) == 0 {
 		return
 	}
-	classes := make([]int, 0, len(s.statusClass))
-	for c := range s.statusClass {
-		classes = append(classes, c)
-	}
-	slices.Sort(classes)
+	classes := slices.Sorted(maps.Keys(s.statusClass))
 	parts := make([]string, 0, len(classes))
 	for _, c := range classes {
 		parts = append(parts, fmt.Sprintf("%dxx %d", c, s.statusClass[c]))

--- a/internal/logging/stats_test.go
+++ b/internal/logging/stats_test.go
@@ -87,12 +87,12 @@ func TestStatsConcurrentRecord(t *testing.T) {
 
 	s := NewStats()
 	var wg sync.WaitGroup
-	for g := 0; g < goroutines; g++ {
+	for g := range goroutines {
 		wg.Add(1)
 		go func(g int) {
 			defer wg.Done()
 			entry := ParseLogEntry(`{"level":"error","status":503,"path":"/api","msg":"upstream down"}`)
-			for i := 0; i < perGoroutine; i++ {
+			for range perGoroutine {
 				s.Record(entry)
 			}
 		}(g)

--- a/internal/logging/theme.go
+++ b/internal/logging/theme.go
@@ -41,26 +41,14 @@ func darkTheme() *Theme {
 	}
 }
 
-// lightTheme is tuned for light terminal backgrounds: the value text becomes
-// black and keys/timestamps use blue instead of the low-contrast white/cyan that
-// the dark theme relies on.
+// lightTheme is tuned for light terminal backgrounds: it is the dark theme with
+// the low-contrast cyan/white swapped for blue/black (DEBUG level, keys, values).
 func lightTheme() *Theme {
-	return &Theme{
-		levels: map[LogLevel]*color.Color{
-			TRACE: color.New(color.FgHiBlack),
-			DEBUG: color.New(color.FgBlue),
-			INFO:  color.New(color.FgGreen),
-			WARN:  color.New(color.FgYellow),
-			ERROR: color.New(color.FgRed),
-			FATAL: color.New(color.FgWhite, color.BgRed, color.Bold),
-		},
-		timestamp: color.New(color.FgBlue),
-		logger:    color.New(color.FgMagenta),
-		key:       color.New(color.FgBlue),
-		value:     color.New(color.FgBlack),
-		quote:     color.New(color.FgHiBlack),
-		errorText: color.New(color.FgRed, color.Bold),
-	}
+	t := darkTheme()
+	t.levels[DEBUG] = color.New(color.FgBlue)
+	t.key = color.New(color.FgBlue)
+	t.value = color.New(color.FgBlack)
+	return t
 }
 
 // activeTheme is the theme used by the formatter. It is configured once at

--- a/internal/terminal/sanitize.go
+++ b/internal/terminal/sanitize.go
@@ -17,26 +17,34 @@ import (
 // `range` operator alone would silently turn such bytes into U+FFFD and could
 // leave the raw byte in the output via the unchanged fast path.
 func Sanitize(value string) string {
+	// Fast path: find the first byte/rune that needs escaping. Most values are
+	// clean and return unchanged without touching a builder — this runs many
+	// times per rendered line, so the zero-allocation path matters.
+	start := 0
+	for start < len(value) {
+		r, size := utf8.DecodeRuneInString(value[start:])
+		if (r == utf8.RuneError && size == 1) || (r != '\t' && isUnsafeRune(r)) {
+			break
+		}
+		start += size
+	}
+	if start == len(value) {
+		return value
+	}
+
 	var builder strings.Builder
 	builder.Grow(len(value))
-	changed := false
+	builder.WriteString(value[:start])
 
-	for i := 0; i < len(value); {
+	for i := start; i < len(value); {
 		r, size := utf8.DecodeRuneInString(value[i:])
 		if r == utf8.RuneError && size == 1 {
 			// Invalid UTF-8 byte: escape the raw byte and move on.
-			changed = true
 			fmt.Fprintf(&builder, `\x%02X`, value[i])
 			i++
 			continue
 		}
-		if r == '\t' {
-			builder.WriteRune(r)
-			i += size
-			continue
-		}
-		if isUnsafeRune(r) {
-			changed = true
+		if r != '\t' && isUnsafeRune(r) {
 			if r <= 0xff {
 				fmt.Fprintf(&builder, `\x%02X`, r)
 			} else {
@@ -49,9 +57,6 @@ func Sanitize(value string) string {
 		i += size
 	}
 
-	if !changed {
-		return value
-	}
 	return builder.String()
 }
 

--- a/internal/terminal/sanitize.go
+++ b/internal/terminal/sanitize.go
@@ -23,7 +23,7 @@ func Sanitize(value string) string {
 	start := 0
 	for start < len(value) {
 		r, size := utf8.DecodeRuneInString(value[start:])
-		if (r == utf8.RuneError && size == 1) || (r != '\t' && isUnsafeRune(r)) {
+		if needsEscape(r, size) {
 			break
 		}
 		start += size
@@ -38,26 +38,35 @@ func Sanitize(value string) string {
 
 	for i := start; i < len(value); {
 		r, size := utf8.DecodeRuneInString(value[i:])
-		if r == utf8.RuneError && size == 1 {
-			// Invalid UTF-8 byte: escape the raw byte and move on.
-			fmt.Fprintf(&builder, `\x%02X`, value[i])
-			i++
-			continue
-		}
-		if r != '\t' && isUnsafeRune(r) {
-			if r <= 0xff {
-				fmt.Fprintf(&builder, `\x%02X`, r)
-			} else {
-				fmt.Fprintf(&builder, `\u%04X`, r)
-			}
+		if !needsEscape(r, size) {
+			builder.WriteRune(r)
 			i += size
 			continue
 		}
-		builder.WriteRune(r)
+		switch {
+		case r == utf8.RuneError && size == 1:
+			// Invalid UTF-8 byte: escape the raw byte itself.
+			fmt.Fprintf(&builder, `\x%02X`, value[i])
+		case r <= 0xff:
+			fmt.Fprintf(&builder, `\x%02X`, r)
+		default:
+			fmt.Fprintf(&builder, `\u%04X`, r)
+		}
 		i += size
 	}
 
 	return builder.String()
+}
+
+// needsEscape reports whether the rune decoded at the current position must be
+// escaped: an invalid UTF-8 byte (RuneError with size 1) or an unsafe rune,
+// with tab exempted. The single predicate shared by Sanitize's fast-path scan
+// and its escape loop, so the two can never drift.
+func needsEscape(r rune, size int) bool {
+	if r == utf8.RuneError && size == 1 {
+		return true
+	}
+	return r != '\t' && isUnsafeRune(r)
 }
 
 // isUnsafeRune reports whether r should be escaped before printing to a terminal.


### PR DESCRIPTION
## Summary

A multi-agent code-quality review of the codebase, applied in reviewable batches (one commit each), then re-reviewed with a second multi-agent pass whose findings are fixed in the final commit. Net effect: fewer per-line allocations on the render/filter hot paths, one copy of each previously duplicated mechanism, dead code removed, and current Go (1.21–1.26) idioms throughout. **+632/−587 across 36 files; total test coverage 87.7% → 88.4%.**

## Commits

- **perf: eliminate per-line allocations on the render/filter hot paths** — level predicates parse their target once instead of per line; `fieldValue` stops allocating a `Split` slice on every missing-key probe (~45 probes/JSON line); `--fields` keys classify once at pipeline construction; `terminal.Sanitize` returns clean input with zero allocations; `GetLogs` drops a per-line string→bytes→string round-trip.
- **fix(cmd): validate flags before building the client; unify --level help** — invalid flag combos now report the usage error even with a broken kubeconfig; the `logs` help text listed only 4 of the 6 supported levels; `%q` for untrusted names in errors.
- **refactor: extract shared helpers for duplicated logic** — one `streamLogs` loop for single/multi-stream paths, one `resolveByKind` for virtual-key resolution, one `DisplayTimeLayout` const (was written out 5×), shared pod fetch, `lightTheme` derived from `darkTheme`, level/operator lists flow from `logging` into completion.
- **refactor: remove dead code and redundant timeline ordering** — deletes the production-dead `LogWriter`, `getSingleContainerName`, `hasPreviousContainer`; drops the timeline `order` field (stable sort already preserves insertion order).
- **refactor: modernize to current Go stdlib idioms** — `interface{}`→`any` (35+ sites), `min`/`max`, `slices`/`maps`/`cmp` stdlib, `time.RFC3339`; gopls `modernize` now reports zero findings.
- **test(cmd): cover config path precedence and field-alias wiring** — the two untested user-facing config paths.
- **fix: address code-review findings on the cleanup branch** — see below.

## Behavior changes (deliberate, pinned by tests)

- YAML flow-map logs with an int `status` field now classify by HTTP status exactly like the equivalent JSON line (5xx→ERROR, 4xx→WARN, 2xx→DEBUG). Previously YAML int statuses were accidentally ignored.
- Stream errors now name the pod/container (`error opening log stream for pod/container: ...`); container/pod names in errors are `%q`-quoted (escapes control characters in untrusted names).
- Flag validation errors surface before kubeconfig/client construction.

## Review

An 8-angle multi-agent review of this branch (line-by-line, removed-behavior audit, cross-file trace, reuse/simplification/efficiency/altitude/conventions) surfaced 9 findings; the final commit fixes the 7 actionable ones, including a self-introduced allocation regression in `sortedKeys` and the silent YAML status behavior change (adopted deliberately + test-pinned). The two remaining are informational (documented global-alias leak in a test comment; a latent-only timeline hardening note).

## Testing

After every batch: `go build`, `go vet`, `gofmt -l` (empty), `go test ./...`, `go test -race`, `golangci-lint run` (0 issues). Also clean: gopls `modernize`, `govulncheck`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)