### PR TITLE
fix(logging): close parser, predicate, and stats edge cases from adversarial review

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -24,7 +24,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v7
         with:
-          go-version: '1.26.5'
+          go-version: '1.26.7'
           cache: true
           cache-dependency-path: go.sum
 
@@ -44,7 +44,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v7
         with:
-          go-version: '1.26.5'
+          go-version: '1.26.7'
           cache: true
           cache-dependency-path: go.sum
 
@@ -61,7 +61,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v7
         with:
-          go-version: '1.26.5'
+          go-version: '1.26.7'
           cache: true
           cache-dependency-path: go.sum
 
@@ -80,7 +80,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v7
         with:
-          go-version: '1.26.5'
+          go-version: '1.26.7'
           cache: true
           cache-dependency-path: go.sum
 
@@ -124,7 +124,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v7
         with:
-          go-version: '1.26.5'
+          go-version: '1.26.7'
           cache: true
           cache-dependency-path: go.sum
 

--- a/.github/workflows/releaser.yaml
+++ b/.github/workflows/releaser.yaml
@@ -32,7 +32,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v7
         with:
-          go-version: '1.26.5'
+          go-version: '1.26.7'
           cache: true
           cache-dependency-path: go.sum
       

--- a/internal/kubernetes/logs.go
+++ b/internal/kubernetes/logs.go
@@ -182,21 +182,22 @@ func (lf *LogFetcher) GetLogs(ctx context.Context) error {
 	}
 
 	pipeline := lf.newPipeline()
-	err := lf.streamLogs(ctx, lf.Namespace, lf.PodName, lf.ContainerName, pipeline, func(line string) error {
+	// The digest is written even when the stream failed, mirroring
+	// fanInStreams: --stats over a container that died mid-fetch still reports
+	// everything read before the failure instead of printing nothing.
+	streamErr := lf.streamLogs(ctx, lf.Namespace, lf.PodName, lf.ContainerName, pipeline, func(line string) error {
 		if _, err := fmt.Fprintln(lf.Writer, line); err != nil {
 			return fmt.Errorf("error writing log line: %w", err)
 		}
 		return nil
 	})
-	if err != nil {
-		return err
-	}
 
 	if stats := pipeline.Stats(); stats != nil {
-		return stats.Write(lf.Writer)
+		if werr := stats.Write(lf.Writer); werr != nil && streamErr == nil {
+			return werr
+		}
 	}
-
-	return nil
+	return streamErr
 }
 
 // streamLogs opens the log stream for one container and drives pipeline over it

--- a/internal/kubernetes/stats_digest_test.go
+++ b/internal/kubernetes/stats_digest_test.go
@@ -1,0 +1,88 @@
+package kubernetes
+
+import (
+	"bytes"
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/dantech2000/logx/internal/logging"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/kubernetes/fake"
+	clientgotesting "k8s.io/client-go/testing"
+)
+
+// TestGetLogsWritesStatsDigestOnStreamError pins that a single-stream --stats
+// run still writes its digest when the log stream fails. GetLogs used to return
+// the stream error before writing, so `logx logs pod --stats` on a container
+// that died mid-fetch printed nothing — while the multi-stream path
+// (fanInStreams) deliberately writes the aggregate over what succeeded.
+func TestGetLogsWritesStatsDigestOnStreamError(t *testing.T) {
+	logging.ApplyColorMode(logging.ColorNever)
+	t.Cleanup(func() { logging.ApplyColorMode(logging.ColorAuto) })
+
+	clientset := fake.NewSimpleClientset()
+	clientset.PrependReactor("get", "pods/log", func(action clientgotesting.Action) (bool, runtime.Object, error) {
+		return true, nil, context.DeadlineExceeded // simulate a failed fetch
+	})
+
+	pod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{Name: "p", Namespace: "default"},
+		Spec:       corev1.PodSpec{Containers: []corev1.Container{{Name: "app"}}},
+	}
+	if _, err := clientset.CoreV1().Pods("default").Create(context.Background(), pod, metav1.CreateOptions{}); err != nil {
+		t.Fatalf("create pod: %v", err)
+	}
+
+	var buf bytes.Buffer
+	fetcher := NewLogFetcher(clientset, "default", "p", false, false, &buf)
+	fetcher.ContainerName = "app"
+	fetcher.FilterLevel = logging.DEBUG
+	fetcher.Filters = logging.PipelineOptions{CollectStats: true}
+
+	if err := fetcher.GetLogs(context.Background()); err == nil {
+		t.Fatal("GetLogs should report the stream error")
+	}
+	if out := buf.String(); !strings.Contains(out, "logx stats") {
+		t.Fatalf("stats digest missing on stream failure, got:\n%s", out)
+	}
+}
+
+// TestGetLogsWritesStatsDigestAfterSuccess pins the happy path: with --stats and
+// a successful stream the digest is written exactly once.
+func TestGetLogsWritesStatsDigestAfterSuccess(t *testing.T) {
+	logging.ApplyColorMode(logging.ColorNever)
+	t.Cleanup(func() { logging.ApplyColorMode(logging.ColorAuto) })
+
+	clientset := fake.NewSimpleClientset()
+	clientset.PrependReactor("get", "pods/log", func(action clientgotesting.Action) (bool, runtime.Object, error) {
+		return true, &runtime.Unknown{Raw: []byte("INFO hello\nERROR boom")}, nil
+	})
+
+	pod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{Name: "p", Namespace: "default"},
+		Spec:       corev1.PodSpec{Containers: []corev1.Container{{Name: "app"}}},
+	}
+	if _, err := clientset.CoreV1().Pods("default").Create(context.Background(), pod, metav1.CreateOptions{}); err != nil {
+		t.Fatalf("create pod: %v", err)
+	}
+
+	var buf bytes.Buffer
+	fetcher := NewLogFetcher(clientset, "default", "p", false, false, &buf)
+	fetcher.ContainerName = "app"
+	fetcher.FilterLevel = logging.DEBUG
+	fetcher.Filters = logging.PipelineOptions{CollectStats: true}
+
+	if err := fetcher.GetLogs(context.Background()); err != nil {
+		t.Fatalf("GetLogs error: %v", err)
+	}
+	out := buf.String()
+	if strings.Count(out, "logx stats") != 1 {
+		t.Fatalf("expected exactly one digest, got:\n%s", out)
+	}
+	if !strings.Contains(out, "lines: 2") {
+		t.Fatalf("digest did not count both lines:\n%s", out)
+	}
+}

--- a/internal/logging/fixes_regression_test.go
+++ b/internal/logging/fixes_regression_test.go
@@ -1,0 +1,285 @@
+package logging
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+	"time"
+)
+
+// Regression tests for the adversarial-review fixes. Each test pins one fix so
+// a revert shows up as a named failure.
+
+// TestWhereEqualsAcceptsDecimalLiteral pins that an equality predicate with a
+// decimal literal ("404.0") matches an integral field value. The integer
+// fast-path in FieldPredicate.equals used to return early and skip the float
+// comparison, so `status==404.0` matched nothing at all.
+func TestWhereEqualsAcceptsDecimalLiteral(t *testing.T) {
+	pred, err := ParseFieldPredicate("status==404.0")
+	if err != nil {
+		t.Fatalf("ParseFieldPredicate: %v", err)
+	}
+	entry := ParseLogEntry(`{"status": 404, "msg": "not found"}`)
+	if !pred.Eval(entry) {
+		t.Errorf("status==404.0 did not match field value 404")
+	}
+
+	neg, err := ParseFieldPredicate("status==404.5")
+	if err != nil {
+		t.Fatalf("ParseFieldPredicate: %v", err)
+	}
+	if neg.Eval(entry) {
+		t.Errorf("status==404.5 matched field value 404")
+	}
+}
+
+// TestWhereEqualsKeepsIntegerPrecision pins that two integer literals are still
+// compared as integers (not through float64), so a 19-digit span ID beyond the
+// 53-bit mantissa does not collide with its neighbor.
+func TestWhereEqualsKeepsIntegerPrecision(t *testing.T) {
+	pred, err := ParseFieldPredicate("span_id==1234567890123456789")
+	if err != nil {
+		t.Fatalf("ParseFieldPredicate: %v", err)
+	}
+	entry := ParseLogEntry(`{"span_id": 1234567890123456789, "msg": "x"}`)
+	if !pred.Eval(entry) {
+		t.Errorf("exact 19-digit integer equality failed")
+	}
+	other := ParseLogEntry(`{"span_id": 1234567890123456000, "msg": "x"}`)
+	if pred.Eval(other) {
+		t.Errorf("19-digit integer equality matched a float64-collapsed neighbor")
+	}
+}
+
+// TestLogfmtUnescapeValues pins that quoted logfmt values collapse escaped
+// backslashes and quotes while keeping every other escape verbatim. Dropping
+// the backslash unconditionally corrupted Windows paths ("C:\temp" → "C:temp").
+// Control-character escapes are deliberately left as text: decoding \n would
+// smuggle a newline into what must stay a single output line, and a viewer is
+// best served by showing the producer's bytes.
+func TestLogfmtUnescapeValues(t *testing.T) {
+	tests := []struct {
+		name      string
+		line      string
+		wantValue string
+	}{
+		{
+			name:      "windows path keeps its backslashes",
+			line:      `level=info msg="C:\temp\dir"`,
+			wantValue: `C:\temp\dir`,
+		},
+		{
+			name:      "escaped backslash collapses",
+			line:      `level=info msg="a\\b"`,
+			wantValue: `a\b`,
+		},
+		{
+			name:      "escaped quote collapses",
+			line:      `level=info msg="say \"hi\""`,
+			wantValue: `say "hi"`,
+		},
+		{
+			name:      "newline escape stays textual",
+			line:      `level=info msg="line1\nline2"`,
+			wantValue: `line1\nline2`,
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			entry := levelOf(t, tc.line)
+			got, ok := entry.Fields["msg"]
+			if !ok {
+				t.Fatalf("no msg field in %v", entry.Fields)
+			}
+			if got != tc.wantValue {
+				t.Errorf("msg = %q, want %q", got, tc.wantValue)
+			}
+		})
+	}
+}
+
+// TestJSONRejectsTrailingContent pins that content after the closing brace is
+// not silently swallowed. json.Decoder reads only the first value, so
+// "{...}{...}" used to drop the second object entirely (its level and message
+// with it) and "{...} garbage" parsed as if the garbage were not there.
+func TestJSONRejectsTrailingContent(t *testing.T) {
+	tests := []struct {
+		name       string
+		line       string
+		wantFormat LogFormat
+		wantLevel  LogLevel
+		wantMsg    string
+	}{
+		{
+			name:       "second concatenated object is not dropped",
+			line:       `{"msg":"two","level":"warn"}{"msg":"other","level":"error"}`,
+			wantFormat: FormatPlainText,
+			wantLevel:  WARN, // mid-line fallback scan finds WARN before ERROR
+			wantMsg:    "",
+		},
+		{
+			name:       "trailing garbage falls back to plain text",
+			line:       `{"level":"info","msg":"hi"} trailing garbage}`,
+			wantFormat: FormatPlainText,
+			// The whole line becomes content; the fallback scan reads "info"
+			// from it, which is the documented over-inclusion tradeoff.
+			wantLevel: INFO,
+		},
+		{
+			name:       "valid single object still parses as JSON",
+			line:       `{"level":"info","msg":"hi"}`,
+			wantFormat: FormatJSON,
+			wantLevel:  INFO,
+		},
+		{
+			name:       "trailing whitespace is allowed",
+			line:       `{"level":"info","msg":"hi"}   `,
+			wantFormat: FormatJSON,
+			wantLevel:  INFO,
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			entry := levelOf(t, tc.line)
+			if entry.Format != tc.wantFormat {
+				t.Errorf("format = %v, want %v", entry.Format, tc.wantFormat)
+			}
+			if entry.Level != tc.wantLevel {
+				t.Errorf("level = %v, want %v", entry.Level, tc.wantLevel)
+			}
+			if tc.wantMsg != "" && entry.Message != tc.wantMsg {
+				t.Errorf("message = %q, want %q", entry.Message, tc.wantMsg)
+			}
+		})
+	}
+}
+
+// TestCompactDateStringIsNotEpoch pins that a YYYYMMDD string timestamp is read
+// as a date, not as epoch seconds. Interpreting "20260624" numerically always
+// lands in 1970–1973, stamping the entry half a century into the past.
+func TestCompactDateStringIsNotEpoch(t *testing.T) {
+	entry := levelOf(t, `{"time":"20260624","msg":"compact date"}`)
+	want := time.Date(2026, 6, 24, 0, 0, 0, 0, time.UTC)
+	if !entry.Timestamp.Equal(want) {
+		t.Errorf("timestamp = %v, want %v", entry.Timestamp.UTC(), want)
+	}
+
+	// Real epoch values keep working, including ones of the same length that do
+	// not form a valid calendar date.
+	for _, tc := range []struct {
+		value string
+		want  time.Time
+	}{
+		{"1750759200", time.Unix(1750759200, 0).UTC()},
+		{"20261399", time.Unix(20261399, 0).UTC()}, // month 13: not a date, is epoch
+	} {
+		entry := levelOf(t, `{"time":"`+tc.value+`","msg":"epoch"}`)
+		if got := entry.Timestamp.UTC(); !got.Equal(tc.want) {
+			t.Errorf("time %q: timestamp = %v, want %v", tc.value, got, tc.want)
+		}
+	}
+}
+
+// TestDuplicateTrailingFieldsLastWins pins that repeated trailing fields resolve
+// to their last occurrence, matching the logfmt parser's forward semantics.
+// Backward iteration used to overwrite in reverse, so the first occurrence won.
+func TestDuplicateTrailingFieldsLastWins(t *testing.T) {
+	entry := levelOf(t, "[2026-06-24 10:00:00] [ERROR] [svc] request failed id=7 id=8")
+	got, ok := entry.Fields["id"]
+	if !ok {
+		t.Fatalf("no id field in %v", entry.Fields)
+	}
+	if got != "8" {
+		t.Errorf("id = %v, want 8", got)
+	}
+	if msg := entry.Message; strings.Contains(msg, "id=") {
+		t.Errorf("message still carries field tokens: %q", msg)
+	}
+}
+
+// TestXMLFormatLabel pins that XML entries carry FormatXML so --output json
+// reports format "xml". They reused FormatLogfmt, mislabeling every XML line.
+func TestXMLFormatLabel(t *testing.T) {
+	entry := levelOf(t, `<log level="ERROR" ts="2026-06-24T10:00:00Z">boom</log>`)
+	if entry.Format != FormatXML {
+		t.Fatalf("format = %v, want %v", entry.Format, FormatXML)
+	}
+	var obj struct {
+		Format string `json:"format"`
+		Level  string `json:"level"`
+	}
+	if err := json.Unmarshal([]byte(MarshalEntryJSON(entry)), &obj); err != nil {
+		t.Fatalf("MarshalEntryJSON: %v", err)
+	}
+	if obj.Format != "xml" {
+		t.Errorf("json format label = %q, want %q", obj.Format, "xml")
+	}
+	if obj.Level != "ERROR" {
+		t.Errorf("json level = %q, want ERROR", obj.Level)
+	}
+}
+
+// TestYAMLFlowIntTimestamp pins that an integer epoch scalar in a flow-style
+// YAML map produces a timestamp. yaml.v2 decodes integers as int, which the
+// float64/json.Number/string switch used to skip entirely.
+func TestYAMLFlowIntTimestamp(t *testing.T) {
+	entry := levelOf(t, `{level: info, msg: hi, ts: 1750759200}`)
+	want := time.Unix(1750759200, 0).UTC()
+	if got := entry.Timestamp.UTC(); !got.Equal(want) {
+		t.Errorf("timestamp = %v, want %v", got, want)
+	}
+}
+
+// TestLeadingTimestampRequiresSeparator pins that a timestamp candidate glued
+// to following text ("...Zerror") is neither extracted as the entry's time nor
+// left behind in the message after the [timestamp] prefix was rendered from it.
+func TestLeadingTimestampRequiresSeparator(t *testing.T) {
+	line := "2026-06-24T10:00:00Zerror boom"
+	entry := levelOf(t, line)
+	if !entry.Timestamp.IsZero() {
+		t.Errorf("glued timestamp was extracted: %v", entry.Timestamp)
+	}
+	if entry.Message != line {
+		t.Errorf("message = %q, want the untouched line %q", entry.Message, line)
+	}
+
+	// The leading-level regex shares the terminated-timestamp shape, so the same
+	// glued prefix is not read as <time><level> either: "Zerror" must not be
+	// trusted as a marker (the fallback scan's alphanumeric guard rejects it,
+	// and there is no other level token on the line).
+	glued := levelOf(t, "2026-06-24T10:00:00Zerror something broke")
+	if glued.LevelDetected {
+		t.Errorf("glued prefix was classified as %v via a detected level", glued.Level)
+	}
+	if glued.Message != "2026-06-24T10:00:00Zerror something broke" {
+		t.Errorf("glued message = %q", glued.Message)
+	}
+
+	// A properly separated timestamp is still extracted and stripped.
+	ok := levelOf(t, "2026-06-24T10:00:00Z ERROR boom")
+	want := time.Date(2026, 6, 24, 10, 0, 0, 0, time.UTC)
+	if !ok.Timestamp.Equal(want) {
+		t.Errorf("separated timestamp = %v, want %v", ok.Timestamp.UTC(), want)
+	}
+	if ok.Level != ERROR || !ok.LevelDetected {
+		t.Errorf("level = %v (detected=%v), want ERROR", ok.Level, ok.LevelDetected)
+	}
+	if ok.Message != "boom" {
+		t.Errorf("message = %q, want %q", ok.Message, "boom")
+	}
+
+	// Bracketed timestamps still work, with and without a leading level token.
+	for _, line := range []string{
+		"[2026-06-24 10:00:00] [ERROR] svc failed",
+		"[2026-06-24 10:00:00] ERROR svc failed",
+		"2026-06-24T10:00:00Z\tERROR boom",
+	} {
+		bracketed := levelOf(t, line)
+		if !bracketed.Timestamp.Equal(want) {
+			t.Errorf("%q: timestamp = %v, want %v", line, bracketed.Timestamp.UTC(), want)
+		}
+		if bracketed.Level != ERROR {
+			t.Errorf("%q: level = %v, want ERROR", line, bracketed.Level)
+		}
+	}
+}

--- a/internal/logging/format.go
+++ b/internal/logging/format.go
@@ -261,7 +261,7 @@ func FormatLogEntryDetails(entry LogEntry) string {
 	switch entry.Format {
 	case FormatJSON:
 		return formatJSONDetails(entry)
-	case FormatBracketed, FormatLogfmt:
+	case FormatBracketed, FormatLogfmt, FormatXML:
 		return formatStructuredDetails(entry)
 	default:
 		return formatPlainTextDetails(entry)

--- a/internal/logging/output_json.go
+++ b/internal/logging/output_json.go
@@ -39,6 +39,7 @@ var formatNames = map[LogFormat]string{
 	FormatJSON:      "json",
 	FormatBracketed: "bracketed",
 	FormatLogfmt:    "logfmt",
+	FormatXML:       "xml",
 }
 
 // jsonEntry is the normalized shape emitted by --output json. It is intentionally

--- a/internal/logging/parser.go
+++ b/internal/logging/parser.go
@@ -19,6 +19,7 @@ const (
 	FormatJSON
 	FormatBracketed
 	FormatLogfmt
+	FormatXML
 )
 
 // LogEntry represents a parsed log entry with all possible fields
@@ -135,10 +136,13 @@ var (
 	// timestamp — "Scheduled next backup for 2026-12-25" was stamped with a date
 	// six months in the future, which corrupts --timeline ordering, `ts`
 	// predicates, and the .time field of --output json. A real entry timestamp is
-	// a prefix by universal convention; a date further in is content.
+	// a prefix by universal convention; a date further in is content. A trailing
+	// separator (whitespace, `]`, `:`, or end of line) is required too, so a
+	// value merely glued to the match ("...Zerror") is not extracted as the
+	// entry's time and then also left behind in the rendered message.
 	plainTextLeadingTimestampRegex = regexp.MustCompile(
-		`^[\s\[]*(?:(?i:DEBUG|INFO|WARN(?:ING)?|ERROR|FATAL|TRACE)\]?\s+\[?)?(` +
-			plainTextTimestampPattern + `)`)
+		`^[\s\[]*(?:(?i:DEBUG|INFO|WARN(?:ING)?|ERROR|FATAL)\]?\s+\[?)?(` +
+			plainTextTimestampPattern + `)(?:[\s\]:]|$)`)
 	// Level detection in plain text uses two regexes, because the cost of a
 	// mistake is asymmetric. Reading prose as ERROR or WARN is over-inclusion: the
 	// line is still shown. Reading it as TRACE is the one direction that loses
@@ -149,9 +153,16 @@ var (
 	// plainTextLeadingLevelRegex matches a level in the position a real marker
 	// occupies: the head of the line, optionally after a timestamp and/or
 	// brackets, and followed by a separator. Every level, TRACE included, is
-	// trusted here.
+	// trusted here. Its optional leading timestamp carries the same trailing-
+	// separator requirement as plainTextLeadingTimestampRegex, so the two
+	// regexes cannot disagree about where a timestamp ends: without it,
+	// "2026-06-24T10:00:00Zerror boom" was rejected as a timestamp (glued) yet
+	// still read as <time><level> and classified ERROR from the prose "error".
+	// With it, both regexes reject the glued prefix, the fallback scan's
+	// alphanumeric guard keeps "Zerror" from matching either, and the line stays
+	// an unclassified DEBUG with its content untouched.
 	plainTextLeadingLevelRegex = regexp.MustCompile(
-		`^[\s\[]*(?:` + plainTextTimestampPattern + `)?[\s\]\[]*` +
+		`^[\s\[]*(?:` + plainTextTimestampPattern + `(?:[\s\]:]|$))?[\s\]\[]*` +
 			`((?i:TRACE|DEBUG|INFO|WARN(?:ING)?|ERROR|FATAL))(?:[\s\]:]|$)`)
 
 	// plainTextLevelRegex is the fallback scan over the rest of the line, for
@@ -207,6 +218,14 @@ func (jsonLogParser) Parse(line string) (LogEntry, bool) {
 	decoder := json.NewDecoder(strings.NewReader(trimmedLine))
 	decoder.UseNumber()
 	if err := decoder.Decode(&data); err != nil {
+		return LogEntry{}, false
+	}
+	// Decode reads only the first JSON value. Accepting trailing content made
+	// "{...} garbage" parse with the garbage dropped, and "{...}{...}" lose the
+	// second object entirely — its level and message silently discarded.
+	// Rejecting lets the line fall through to the plain-text parser, which keeps
+	// all of it as the message.
+	if decoder.More() {
 		return LogEntry{}, false
 	}
 	return parseJSONLog(trimmedLine, data), true
@@ -509,8 +528,16 @@ func parseJSONTimestamp(data map[string]any) time.Time {
 					return ts
 				}
 			}
+			// yaml.v2 decodes integer scalars as int, not json.Number; without
+			// these cases a YAML flow map's epoch timestamp was silently ignored.
+			switch numTime := val.(type) {
+			case int:
+				return parseUnixTimestampInt(int64(numTime))
+			case int64:
+				return parseUnixTimestampInt(numTime)
+			}
 			if timeStr, ok := val.(string); ok {
-				if ts, ok := parseUnixTimestampString(timeStr); ok {
+				if ts, ok := parseStringTimestamp(timeStr); ok {
 					return ts
 				}
 				if ts, err := parseTimestamp(timeStr); err == nil {
@@ -520,6 +547,33 @@ func parseJSONTimestamp(data map[string]any) time.Time {
 		}
 	}
 	return time.Time{}
+}
+
+// parseStringTimestamp interprets a timestamp field's string value as either
+// epoch seconds/millis or an already-formatted time.
+//
+// The epoch interpretation runs second because it is the more dangerous guess:
+// an 8-digit run that is also a valid calendar date ("20260624") parses as both,
+// but as epoch seconds it always lands in 1970–1973, silently stamping every
+// such entry half a century into the past. A valid YYYYMMDD date therefore wins;
+// anything that fails the date layout (a real epoch value like "1750759200", or
+// "20261399", which is no month at all) still parses numerically below.
+func parseStringTimestamp(value string) (time.Time, bool) {
+	if len(value) == 8 && isAllDigits(value) {
+		if ts, err := time.Parse("20060102", value); err == nil {
+			return ts, true
+		}
+	}
+	return parseUnixTimestampString(value)
+}
+
+func isAllDigits(s string) bool {
+	for i := 0; i < len(s); i++ {
+		if s[i] < '0' || s[i] > '9' {
+			return false
+		}
+	}
+	return true
 }
 
 func parseUnixTimestamp(value float64) time.Time {
@@ -707,7 +761,11 @@ func splitTrailingFields(message string) (string, map[string]any) {
 		if fields == nil {
 			fields = make(map[string]any)
 		}
-		fields[key] = strings.Trim(value, `"`)
+		// Backward iteration visits the last occurrence first; skipping repeats
+		// keeps last-wins semantics, matching the logfmt parser.
+		if _, exists := fields[key]; !exists {
+			fields[key] = strings.Trim(value, `"`)
+		}
 		fieldStart = i
 	}
 
@@ -766,23 +824,7 @@ func parseLogfmtFields(line string) (map[string]any, bool) {
 
 		value := ""
 		if i < len(line) && line[i] == '"' {
-			i++
-			var builder strings.Builder
-			for i < len(line) {
-				if line[i] == '\\' && i+1 < len(line) {
-					i++
-					builder.WriteByte(line[i])
-					i++
-					continue
-				}
-				if line[i] == '"' {
-					i++
-					break
-				}
-				builder.WriteByte(line[i])
-				i++
-			}
-			value = builder.String()
+			value, i = scanQuotedLogfmtValue(line, i)
 		} else {
 			valueStart := i
 			for i < len(line) && line[i] != ' ' {
@@ -794,6 +836,39 @@ func parseLogfmtFields(line string) (map[string]any, bool) {
 	}
 
 	return fields, len(fields) > 0
+}
+
+// scanQuotedLogfmtValue reads a double-quoted logfmt value starting at the
+// opening quote line[i] and returns the decoded value plus the index just past
+// the closing quote (or end of line, for an unterminated value).
+//
+// Escaped backslash and quote collapse to the bare byte; any other escape keeps
+// both characters. Dropping the backslash unconditionally corrupted values like
+// "C:\temp" into "C:temp", and decoding \n would smuggle a newline into what
+// must stay a single output line.
+func scanQuotedLogfmtValue(line string, i int) (string, int) {
+	i++ // opening quote
+	var builder strings.Builder
+	for i < len(line) {
+		if line[i] == '\\' && i+1 < len(line) {
+			i++
+			if line[i] == '\\' || line[i] == '"' {
+				builder.WriteByte(line[i])
+			} else {
+				builder.WriteByte('\\')
+				builder.WriteByte(line[i])
+			}
+			i++
+			continue
+		}
+		if line[i] == '"' {
+			i++
+			break
+		}
+		builder.WriteByte(line[i])
+		i++
+	}
+	return builder.String(), i
 }
 
 func firstStringField(fields map[string]any, names ...string) (string, bool) {

--- a/internal/logging/parser_formats.go
+++ b/internal/logging/parser_formats.go
@@ -2,6 +2,8 @@ package logging
 
 import (
 	"encoding/csv"
+	"errors"
+	"io"
 	"regexp"
 	"strings"
 
@@ -23,7 +25,14 @@ func (yamlFlowParser) Parse(line string) (LogEntry, bool) {
 		return LogEntry{}, false
 	}
 	var data map[string]any
-	if err := yaml.Unmarshal([]byte(trimmed), &data); err != nil || len(data) == 0 {
+	// A decoder (rather than Unmarshal) also lets us reject trailing content:
+	// Decode reads one document, so "{...}{...}" or "{...} garbage" would
+	// otherwise parse with everything after the first map silently dropped.
+	decoder := yaml.NewDecoder(strings.NewReader(trimmed))
+	if err := decoder.Decode(&data); err != nil || len(data) == 0 {
+		return LogEntry{}, false
+	}
+	if err := decoder.Decode(new(any)); !errors.Is(err, io.EOF) {
 		return LogEntry{}, false
 	}
 	// Require a recognized level or message key so a stray "{note: ...}" or a code
@@ -110,7 +119,7 @@ func (xmlLogParser) Parse(line string) (LogEntry, bool) {
 	// Level defaults to DEBUG to match every other parser's undetected-level
 	// default. Leaving it as the zero value would mean TRACE, which sits below
 	// the default --level and would hide every XML line lacking a level attribute.
-	entry := LogEntry{Level: DEBUG, Format: FormatLogfmt, Fields: fields, RawLine: line}
+	entry := LogEntry{Level: DEBUG, Format: FormatXML, Fields: fields, RawLine: line}
 	if level, ok := parseJSONLevel(fields); ok {
 		entry.Level, entry.LevelDetected = level, true
 	}

--- a/internal/logging/predicate.go
+++ b/internal/logging/predicate.go
@@ -254,10 +254,14 @@ func (fp FieldPredicate) equals(str string) bool {
 	}
 	// Integers are compared as integers so that a 19-digit trace or span ID is
 	// not collapsed by float64's 53-bit mantissa, where ...992 and ...993 are the
-	// same value and a predicate would match the wrong span.
-	if a, err := strconv.ParseInt(str, 10, 64); err == nil {
-		b, berr := strconv.ParseInt(fp.val, 10, 64)
-		return berr == nil && a == b
+	// same value and a predicate would match the wrong span. The int path only
+	// applies when both sides are integer literals: returning early here also
+	// skipped the float comparison below, so `status==404.0` never matched a
+	// field of 404.
+	if b, berr := strconv.ParseInt(fp.val, 10, 64); berr == nil {
+		if a, aerr := strconv.ParseInt(str, 10, 64); aerr == nil {
+			return a == b
+		}
 	}
 	n, err := strconv.ParseFloat(str, 64)
 	return err == nil && n == fp.num


### PR DESCRIPTION
Nine bugs found in an adversarial code review, each fixed and pinned by a regression test.

## Fixes

- **`--where field==N.0` matched nothing** — the integer fast-path in `FieldPredicate.equals` returned before the float comparison. Decimal literals now fall through to it; two integer literals still compare as int64 so 19-digit span IDs keep full precision.
- **logfmt escapes corrupted values** — backslashes were dropped unconditionally (`"C:\temp\dir"` → `"C:tempdir"`, `\n` → `n`). Only `\\` and `\"` collapse now; every other escape keeps both characters.
- **JSON parser swallowed trailing content** — `Decode` reads one value, so `{...}{...}` silently lost the second object's level and message and `{...} garbage}` parsed clean. Both are rejected now; the same single-document rule was applied to YAML flow maps via a `yaml.Decoder`.
- **Compact dates misread as epoch** — `{"time":"20260624"}` landed in 1970 because numeric parsing ran before layout parsing. A valid YYYYMMDD date now wins; real epochs (and non-dates like `20261399`) still parse numerically.
- **YAML flow maps dropped integer epochs** — yaml.v2 decodes integer scalars as `int`, which the float64/json.Number/string switch skipped.
- **Glued timestamp prefixes** — `2026-06-24T10:00:00Zerror ...` had its prefix extracted as the entry time *and* left in the message; worse, the leading-level regex still trusted the glued "error". Both leading regexes now share the same terminated-timestamp shape, so the line stays an unclassified DEBUG with content untouched.
- **Duplicate trailing fields resolved first-wins** — backward iteration overwrote in reverse; last-wins now matches logfmt semantics.
- **XML entries labeled `format: logfmt`** — new `FormatXML`; JSON output reports `"xml"`.
- **Single-stream `--stats` lost its digest on stream failure** — `GetLogs` returned before writing; it now writes the digest even on error, matching `fanInStreams`.

## Testing

- New table-driven tests: `internal/logging/fixes_regression_test.go`, `internal/kubernetes/stats_digest_test.go`
- Full gate green: build, vet, gofmt, `go test -race ./...`, golangci-lint 0 issues
- Verified against a live cluster (Rancher Desktop k3s): pod emitting every bug shape checked across plain/`--output json`/`--where status==404.0`/`--timeline`/`--stats`/`--selector` fan-out and a Ctrl-C'd `--follow`