### PR TITLE
fix(main): sanitize error messages written to stderr

### DIFF
--- a/main.go
+++ b/main.go
@@ -5,11 +5,12 @@ import (
 	"os"
 
 	"github.com/dantech2000/logx/cmd"
+	"github.com/dantech2000/logx/internal/terminal"
 )
 
 func main() {
 	if err := cmd.Execute(); err != nil {
-		fmt.Fprintln(os.Stderr, "Error:", err)
+		fmt.Fprintln(os.Stderr, "Error:", terminal.Sanitize(err.Error()))
 		os.Exit(1)
 	}
 }

--- a/main_test.go
+++ b/main_test.go
@@ -1,0 +1,38 @@
+package main
+
+import (
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestMainErrorIsSanitized(t *testing.T) {
+	bin := filepath.Join(t.TempDir(), "logx")
+	build := exec.Command("go", "build", "-o", bin, ".")
+	if out, err := build.CombinedOutput(); err != nil {
+		t.Fatalf("go build: %v\n%s", err, out)
+	}
+
+	// Trigger an error that contains a non-existent kubeconfig path. The error
+	// message itself is safe, but this exercises the stderr write path where
+	// Sanitize now runs.
+	cmd := exec.Command(bin, "--kubeconfig", filepath.Join(t.TempDir(), "nope"), "logs", "x")
+	var stderr strings.Builder
+	cmd.Stderr = &stderr
+	_ = cmd.Run()
+
+	if stderr.Len() == 0 {
+		t.Fatal("expected error output on stderr, got nothing")
+	}
+
+	// The output must not contain raw C0 control characters (except tab, which
+	// Sanitize passes through). This is a structural guarantee: every byte that
+	// reaches stderr has been filtered.
+	out := stderr.String()
+	for i, b := range []byte(out) {
+		if b < 0x20 && b != '\t' && b != '\n' {
+			t.Errorf("raw control byte 0x%02X at offset %d in stderr: %q", b, i, out)
+		}
+	}
+}


### PR DESCRIPTION
Error messages from the Kubernetes layer embed pod/container identifiers that could carry terminal escape sequences from a hostile cluster. The stderr write in `main.go` was the one render path that bypassed `terminal.Sanitize`, breaking the documented invariant that everything printed goes through the chokepoint.

Apply `Sanitize` to the error string before writing to stderr. Add a subprocess test that builds the binary and asserts no raw control bytes reach the output.

**Security audit finding:** Low-severity inconsistency — all other output paths (log lines, JSON, stats, timeline) go through `terminal.Sanitize`, but the error path in `main.go` did not.