### PR TITLE
fix(release): emit postflight_steps in the Homebrew cask

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -77,13 +77,17 @@ homebrew_casks:
     homepage: 'https://github.com/dantech2000/logx'
     description: 'Enhanced Kubernetes pod log viewer'
     license: 'MIT'
-    hooks:
-      post:
-        install: |
-          if OS.mac?
-            system_command "/usr/bin/xattr", args: ["-dr", "com.apple.quarantine", "#{staged_path}/logx"]
-            system_command "/usr/bin/xattr", args: ["-dr", "com.apple.quarantine", "#{staged_path}/kubectl-logx"]
-          end
+    # The release binaries are not Developer ID-signed, so clear the download
+    # quarantine after Homebrew stages them. Homebrew 6.0.22 deprecated the Ruby
+    # `postflight` block that `hooks.post.install` emits, so declare the
+    # replacement `postflight_steps` stanza through `custom_block` instead.
+    custom_block: |
+      postflight_steps do
+        on_macos do
+          run "/usr/bin/xattr", args: ["-dr", "com.apple.quarantine", "{{ "{{staged_path}}" }}/logx"]
+          run "/usr/bin/xattr", args: ["-dr", "com.apple.quarantine", "{{ "{{staged_path}}" }}/kubectl-logx"]
+        end
+      end
 
 changelog:
   sort: asc


### PR DESCRIPTION
Homebrew 6.0.22 deprecates the Ruby `postflight` block and warns on every load of the cask GoReleaser publishes to dantech2000/homebrew-tap:

```
Warning: Calling `postflight` is deprecated! Use `postflight_steps` instead.
```

GoReleaser's cask template hard-codes `postflight do ... end` around `hooks.post.install` and has no option for the new stanza, so this drops the hook and declares `postflight_steps` through `custom_block` instead. GoReleaser applies Go templating to the whole rendered cask, so the Homebrew `{{staged_path}}` token is written as `{{ "{{staged_path}}" }}` to come out literally.

Verified with `goreleaser check` and a local `goreleaser release --snapshot` on GoReleaser 2.15.4. The rendered `dist/homebrew/Casks/logx.rb` contains:

```ruby
postflight_steps do
  on_macos do
    run "/usr/bin/xattr", args: ["-dr", "com.apple.quarantine", "{{staged_path}}/logx"]
    run "/usr/bin/xattr", args: ["-dr", "com.apple.quarantine", "{{staged_path}}/kubectl-logx"]
  end
end
```

and Homebrew 6.0.22 loads it as two `run` steps with an `on: macos` guard. `custom_block` lands at the top of the cask, which `brew style` flags as a stanza-order nit; that check is not enforced for third-party taps.

Companion PR that fixes the currently published cask: dantech2000/homebrew-tap#1.
